### PR TITLE
Phase 1c — material draw submission + dispatch

### DIFF
--- a/native/macos/src/lib.rs
+++ b/native/macos/src/lib.rs
@@ -386,6 +386,11 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
     // them to the spec minimums (2^24 BLAS geometries / TLAS instances,
     // etc.) whenever ray query was granted.
     let mut required_limits = wgpu::Limits::default();
+    // Phase 1c: the material ABI declares 5 bind groups (PerFrame,
+    // PerView, PerMaterial, PerDraw, SceneInputs). wgpu's default
+    // limit is 4. Metal / Vulkan / D3D12 support at least 7, so 5 is
+    // safely within every real backend's capabilities.
+    required_limits.max_bind_groups = 5;
     if required_features.intersects(rt_mask) {
         required_limits = required_limits
             .using_minimum_supported_acceleration_structure_values();
@@ -1325,6 +1330,45 @@ pub extern "C" fn bloom_gen_mesh_heightmap(image_handle: f64, size_x: f64, size_
 pub extern "C" fn bloom_load_shader(source_ptr: *const u8) -> f64 {
     let source = str_from_header(source_ptr);
     engine().renderer.load_custom_shader(source) as f64
+}
+
+// ============================================================
+// Phase 1c — material system FFI
+// ============================================================
+
+#[no_mangle]
+pub extern "C" fn bloom_compile_material(source_ptr: *const u8) -> f64 {
+    let source = str_from_header(source_ptr);
+    match engine().renderer.compile_material(source) {
+        Ok(handle) => handle as f64,
+        Err(e) => {
+            eprintln!("[material] compile failed: {:?}", e);
+            0.0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_draw_material(
+    material: f64,
+    mesh_handle: f64,
+    mesh_idx: f64,
+    x: f64, y: f64, z: f64, scale: f64,
+    r: f64, g: f64, b: f64, a: f64,
+) {
+    let eng = engine();
+    let handle_bits = mesh_handle.to_bits();
+    if let Some(model) = eng.models.get(mesh_handle) {
+        let _ = eng.renderer.cache_model_if_static(handle_bits, &model.meshes);
+    }
+    eng.renderer.submit_material_draw(
+        material as u32,
+        handle_bits,
+        mesh_idx as usize,
+        [x as f32, y as f32, z as f32],
+        scale as f32,
+        [(r / 255.0) as f32, (g / 255.0) as f32, (b / 255.0) as f32, (a / 255.0) as f32],
+    );
 }
 
 #[no_mangle]
@@ -2537,6 +2581,14 @@ extern "C" fn bloom_screenshot_capture(out_len: *mut usize) -> *mut u8 {
         eng.renderer.uniform_3d_layout(),
     );
     eng.scene.prepare_materials(&eng.renderer);
+    // Phase 1c: sync material PerFrame + PerView UBOs with the
+    // current engine clock before the main HDR pass dispatches any
+    // material draws that were submitted during this frame.
+    {
+        let t = eng.get_time() as f32;
+        let dt = eng.delta_time as f32;
+        eng.renderer.material_system_begin_frame(t, dt);
+    }
     eng.renderer.end_frame_with_scene(&mut eng.scene, &mut eng.profiler);
 
     match eng.renderer.screenshot_data.take() {

--- a/native/shared/shaders/materials/test_minimal.wgsl
+++ b/native/shared/shaders/materials/test_minimal.wgsl
@@ -1,29 +1,42 @@
-// Minimal ABI-compliant test material.
+// Minimal ABI-compliant test material (opaque profile).
 //
-// Reads PerFrame.time and PerDraw.mvp to render the bound vertex
-// geometry as a solid-colour translucent quad. Proves the compile
-// path in material_pipeline.rs works end-to-end.
+// Reads PerFrame.time and PerDraw.mvp to render the bound geometry
+// with a solid time-pulsed colour. Writes the full 4-MRT G-buffer so
+// the main HDR pass accepts it without a translucent sub-pass (that's
+// phase 2's job). Proves the material pipeline + submission plumbing
+// works end-to-end.
 
 #include "material_abi.wgsl"
 
 struct VsOut {
   @builtin(position) clip_position: vec4<f32>,
-  @location(0) color: vec3<f32>,
+  @location(0) world_normal: vec3<f32>,
+  @location(1) local_color:  vec3<f32>,
 };
 
 @vertex
 fn vs_main(in: VertexInput) -> VsOut {
   var out: VsOut;
-  let world = world_position_from_skinned(in.position, in, true);
   out.clip_position = draw.mvp * vec4<f32>(in.position, 1.0);
-  // Animate a colour pulse by PerFrame.time so the test shader
-  // demonstrably reads from group 0.
-  let pulse = 0.5 + 0.5 * sin(frame.time);
-  out.color = vec3<f32>(pulse, 0.4, 1.0 - pulse) * draw.model_tint.rgb;
+  out.world_normal = normalize((draw.model * vec4<f32>(in.normal, 0.0)).xyz);
+
+  // Pulse colour with PerFrame.time to demonstrate the binding.
+  let pulse = 0.5 + 0.5 * sin(frame.time * 1.5);
+  out.local_color = vec3<f32>(pulse, 0.4, 1.0 - pulse) * draw.model_tint.rgb;
   return out;
 }
 
 @fragment
-fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-  return vec4<f32>(in.color, 0.7);
+fn fs_main(in: VsOut) -> OpaqueOut {
+  var out: OpaqueOut;
+  // Simple directional-ish shading so the cube reads as 3D.
+  let n = normalize(in.world_normal);
+  let light_dir = normalize(vec3<f32>(0.3, 0.7, 0.4));
+  let diffuse = max(dot(n, light_dir), 0.0);
+  let lit = in.local_color * (0.3 + 0.7 * diffuse);
+  out.hdr      = vec4<f32>(lit, 1.0);
+  out.material = vec2<f32>(0.0, 0.9);            // non-metal, rough
+  out.velocity = vec2<f32>(0.0, 0.0);
+  out.albedo   = vec4<f32>(in.local_color, 1.0);
+  return out;
 }

--- a/native/shared/src/renderer/material_system.rs
+++ b/native/shared/src/renderer/material_system.rs
@@ -1,0 +1,473 @@
+// Material system — the runtime state behind Phase 1c.
+//
+// Owns the compiled `MaterialPipeline`s, the per-frame / per-view /
+// per-material / per-draw uniform buffers, the bind groups wiring
+// them to the ABI layouts, and the per-frame draw command list.
+//
+// The Renderer owns one `MaterialSystem` instance. Games interact via
+// three methods: `compile_material`, `submit_draw`, and (internally)
+// `dispatch` which runs inside the main HDR pass.
+
+use wgpu::util::DeviceExt;
+
+use super::material_pipeline::{
+    MaterialAbiLayouts, MaterialPipeline, MaterialCompileDesc, FragmentProfile,
+    compile_material, MaterialCompileError,
+};
+use super::types::Vertex3D;
+
+// =====================================================================
+// Uniform structs — repr(C), bytemuck-Pod, mirror the WGSL in
+// material_abi.wgsl. Kept local to this module so changes to ABI
+// struct layouts happen in exactly one place per language.
+// =====================================================================
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PerFrameUniforms {
+    pub time:              f32,
+    pub delta_time:        f32,
+    pub frame_index:       u32,
+    pub _pad0:             u32,
+    pub screen_resolution: [f32; 2],
+    pub render_resolution: [f32; 2],
+    pub taa_jitter:        [f32; 2],
+    pub _pad1:             [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PerViewDirLight {
+    pub direction: [f32; 4],  // xyz + intensity
+    pub color:     [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PerViewPointLight {
+    pub position: [f32; 4],
+    pub color:    [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PerViewUniforms {
+    pub view:           [[f32; 4]; 4],
+    pub proj:           [[f32; 4]; 4],
+    pub view_proj:      [[f32; 4]; 4],
+    pub prev_view_proj: [[f32; 4]; 4],
+    pub inv_proj:       [[f32; 4]; 4],
+    pub camera_pos:     [f32; 4],
+    pub camera_dir:     [f32; 4],
+    pub ambient:        [f32; 4],
+    pub fog:            [f32; 4],
+    pub sun_dir:        [f32; 4],
+    pub sun_color:      [f32; 4],
+    pub dir_light_count:   [f32; 4],
+    pub dir_lights:        [PerViewDirLight; 4],
+    pub point_light_count: [f32; 4],
+    pub point_lights:      [PerViewPointLight; 16],
+    pub shadow_splits:   [f32; 4],
+    pub shadow_view:     [[f32; 4]; 4],
+    pub shadow_cascades: [[[f32; 4]; 4]; 3],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct MaterialFactorsUniforms {
+    pub metal_rough: [f32; 4],
+    pub emissive:    [f32; 4],
+    pub base_color:  [f32; 4],
+    pub _reserved:   [f32; 4],
+}
+
+impl Default for MaterialFactorsUniforms {
+    fn default() -> Self {
+        Self {
+            metal_rough: [0.0, 1.0, 0.0, 0.0],          // non-metal, rough, no MR tex, no cutoff
+            emissive:    [0.0, 0.0, 0.0, 0.0],
+            base_color:  [1.0, 1.0, 1.0, 1.0],
+            _reserved:   [0.0, 0.0, 0.0, 0.0],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PerDrawUniforms {
+    pub mvp:        [[f32; 4]; 4],
+    pub model:      [[f32; 4]; 4],
+    pub prev_mvp:   [[f32; 4]; 4],
+    pub model_tint: [f32; 4],
+    pub skin_info:  [u32; 4],
+}
+
+// =====================================================================
+// Handles + draw commands
+// =====================================================================
+
+pub type MaterialHandle = u32;
+
+pub struct MaterialDrawCommand {
+    pub material:    MaterialHandle,
+    pub mesh_handle: u64,       // matches model_gpu_cache keys
+    pub mesh_idx:    usize,     // sub-mesh index within that cached model
+    pub draw_slot:   usize,     // which slot in per_draw_buffers to bind
+}
+
+// =====================================================================
+// The system
+// =====================================================================
+
+pub struct MaterialSystem {
+    pub layouts: MaterialAbiLayouts,
+
+    // Compiled pipelines, indexed by MaterialHandle (1-based; 0 = invalid).
+    pub pipelines: Vec<Option<MaterialPipeline>>,
+
+    // Per-frame UBO + bind group (rewritten at the start of every frame).
+    pub per_frame_buffer: wgpu::Buffer,
+    pub per_frame_bg:     wgpu::BindGroup,
+
+    // Per-view UBO — one for now (single camera). Phase 2 may add more
+    // for split-screen / shadow cascades.
+    pub per_view_buffer: wgpu::Buffer,
+    pub per_view_bg:     wgpu::BindGroup,
+
+    // Default per-material bind group: all white 1×1 textures, default
+    // factors, zero-initialised user-params. Materials that don't
+    // provide their own share this.
+    pub default_per_material_bg: wgpu::BindGroup,
+    /// Kept alive so the BG it backs doesn't dangle.
+    _default_material_factors_buffer: wgpu::Buffer,
+    _default_user_params_buffer:      wgpu::Buffer,
+    _default_white_tex:               wgpu::Texture,
+    _default_sampler:                 wgpu::Sampler,
+
+    // Per-draw UBO pool. Buffers grow 1-by-1 as draws pile up.
+    // Each entry is `(PerDraw UBO, bind group binding it + the global
+    // joint buffer at binding 1)`.
+    pub per_draw_buffers: Vec<wgpu::Buffer>,
+    pub per_draw_bgs:     Vec<wgpu::BindGroup>,
+
+    // Frame state
+    pub commands:   Vec<MaterialDrawCommand>,
+    next_draw_slot: usize,
+}
+
+impl MaterialSystem {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        joint_buffer: &wgpu::Buffer,
+    ) -> Self {
+        let layouts = MaterialAbiLayouts::create(device);
+
+        // Per-frame UBO.
+        let per_frame_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("material_per_frame"),
+            size: std::mem::size_of::<PerFrameUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let per_frame_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("material_per_frame_bg"),
+            layout: &layouts.per_frame,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0, resource: per_frame_buffer.as_entire_binding(),
+            }],
+        });
+
+        // Default white 1×1 texture + sampler shared across optional PBR bindings.
+        let default_white_tex = device.create_texture_with_data(
+            queue,
+            &wgpu::TextureDescriptor {
+                label: Some("material_default_white"),
+                size: wgpu::Extent3d { width: 1, height: 1, depth_or_array_layers: 1 },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            },
+            Default::default(),
+            &[255, 255, 255, 255],
+        );
+        let default_white_view = default_white_tex.create_view(&Default::default());
+        let default_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("material_default_samp"),
+            address_mode_u: wgpu::AddressMode::Repeat,
+            address_mode_v: wgpu::AddressMode::Repeat,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Linear,
+            ..Default::default()
+        });
+
+        // Per-view UBO — zero init; write the real data each frame in `begin_frame`.
+        let per_view_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("material_per_view"),
+            size: std::mem::size_of::<PerViewUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        // We don't have the env / BRDF LUT / shadow textures plumbed through
+        // the material-system layout yet — Phase 2 wires them from the
+        // existing renderer state. For now the PerView bind group uses the
+        // default white texture + sampler for the env / BRDF / shadow slots
+        // as placeholders so draws validate.
+        let white_samp = &default_sampler;
+        let white_view = &default_white_view;
+        let cmp_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("material_default_cmp_samp"),
+            compare: Some(wgpu::CompareFunction::LessEqual),
+            ..Default::default()
+        });
+        // PerView layout wants a depth texture for shadow bindings 6-8.
+        // Use a 1×1 depth as a stub.
+        let stub_depth = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("material_stub_depth"),
+            size: wgpu::Extent3d { width: 1, height: 1, depth_or_array_layers: 1 },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let stub_depth_view = stub_depth.create_view(&Default::default());
+        let per_view_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("material_per_view_bg"),
+            layout: &layouts.per_view,
+            entries: &[
+                wgpu::BindGroupEntry { binding: 0, resource: per_view_buffer.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 1, resource: wgpu::BindingResource::TextureView(white_view) },
+                wgpu::BindGroupEntry { binding: 2, resource: wgpu::BindingResource::Sampler(white_samp) },
+                wgpu::BindGroupEntry { binding: 3, resource: wgpu::BindingResource::TextureView(white_view) },
+                wgpu::BindGroupEntry { binding: 4, resource: wgpu::BindingResource::TextureView(white_view) },
+                wgpu::BindGroupEntry { binding: 5, resource: wgpu::BindingResource::Sampler(white_samp) },
+                wgpu::BindGroupEntry { binding: 6, resource: wgpu::BindingResource::TextureView(&stub_depth_view) },
+                wgpu::BindGroupEntry { binding: 7, resource: wgpu::BindingResource::TextureView(&stub_depth_view) },
+                wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(&stub_depth_view) },
+                wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(&cmp_sampler) },
+            ],
+        });
+        // The stub_depth texture and cmp_sampler outlive the bind group via
+        // wgpu internal Arc; we don't need to hold them in the struct.
+        std::mem::forget(stub_depth);
+        std::mem::forget(stub_depth_view);
+        std::mem::forget(cmp_sampler);
+
+        // Default MaterialFactors UBO.
+        let default_mf = MaterialFactorsUniforms::default();
+        let default_material_factors_buffer = device.create_buffer_init(
+            &wgpu::util::BufferInitDescriptor {
+                label: Some("material_default_factors"),
+                contents: bytemuck::bytes_of(&default_mf),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            },
+        );
+        // Default user-params UBO — 256 bytes of zeros (ABI §1.4).
+        let default_user_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("material_default_user_params"),
+            size: 256,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        // Need a SECOND sampler here because wgpu requires distinct sampler
+        // handles when binding the same logical sampler to multiple slots
+        // within one BG — actually it doesn't, the same handle works fine.
+        // We reuse default_sampler for every material-tex sampler slot.
+        let default_per_material_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("material_default_per_material_bg"),
+            layout: &layouts.per_material,
+            entries: &[
+                wgpu::BindGroupEntry { binding: 0,  resource: wgpu::BindingResource::TextureView(&default_white_view) },
+                wgpu::BindGroupEntry { binding: 1,  resource: wgpu::BindingResource::Sampler(&default_sampler) },
+                wgpu::BindGroupEntry { binding: 2,  resource: wgpu::BindingResource::TextureView(&default_white_view) },
+                wgpu::BindGroupEntry { binding: 3,  resource: wgpu::BindingResource::Sampler(&default_sampler) },
+                wgpu::BindGroupEntry { binding: 4,  resource: wgpu::BindingResource::TextureView(&default_white_view) },
+                wgpu::BindGroupEntry { binding: 5,  resource: wgpu::BindingResource::Sampler(&default_sampler) },
+                wgpu::BindGroupEntry { binding: 6,  resource: wgpu::BindingResource::TextureView(&default_white_view) },
+                wgpu::BindGroupEntry { binding: 7,  resource: wgpu::BindingResource::Sampler(&default_sampler) },
+                wgpu::BindGroupEntry { binding: 8,  resource: wgpu::BindingResource::TextureView(&default_white_view) },
+                wgpu::BindGroupEntry { binding: 9,  resource: wgpu::BindingResource::Sampler(&default_sampler) },
+                wgpu::BindGroupEntry { binding: 10, resource: default_material_factors_buffer.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 11, resource: default_user_params_buffer.as_entire_binding() },
+            ],
+        });
+
+        Self {
+            layouts,
+            pipelines: Vec::new(),
+            per_frame_buffer,
+            per_frame_bg,
+            per_view_buffer,
+            per_view_bg,
+            default_per_material_bg,
+            _default_material_factors_buffer: default_material_factors_buffer,
+            _default_user_params_buffer: default_user_params_buffer,
+            _default_white_tex: default_white_tex,
+            _default_sampler: default_sampler,
+            per_draw_buffers: Vec::new(),
+            per_draw_bgs: Vec::new(),
+            commands: Vec::new(),
+            next_draw_slot: 0,
+        }
+    }
+
+    // --- Material registry --------------------------------------------
+
+    /// Compile a material and return its handle. Handles are 1-based;
+    /// 0 is reserved for "invalid material".
+    pub fn compile(
+        &mut self,
+        device: &wgpu::Device,
+        wgsl_source: &str,
+        profile: FragmentProfile,
+        reads_scene: bool,
+        hdr_format: wgpu::TextureFormat,
+        material_format: wgpu::TextureFormat,
+        velocity_format: wgpu::TextureFormat,
+        albedo_format: wgpu::TextureFormat,
+        depth_format: wgpu::TextureFormat,
+    ) -> Result<MaterialHandle, MaterialCompileError> {
+        // Inject the user's WGSL under a synthetic path so the
+        // preprocessor can resolve `#include "material_abi.wgsl"` etc.
+        let entry_path = "__user_material.wgsl";
+        let desc = MaterialCompileDesc {
+            label: "user_material",
+            entry_path,
+            extra_sources: &[(entry_path, wgsl_source)],
+            profile,
+            reads_scene,
+            hdr_format,
+            material_format,
+            velocity_format,
+            albedo_format,
+            depth_format,
+            vertex_buffers: &[Vertex3D::desc()],
+        };
+        let pipeline = compile_material(device, &self.layouts, &desc)?;
+        self.pipelines.push(Some(pipeline));
+        Ok(self.pipelines.len() as MaterialHandle)
+    }
+
+    // --- Frame lifecycle ----------------------------------------------
+
+    /// Write the per-frame + per-view UBOs. Safe to call any time
+    /// before `dispatch`; callers should call exactly once per frame
+    /// to keep `PerFrame.time` accurate. Does NOT clear the commands
+    /// list — that's `reset_frame`'s job (called at begin_frame, not
+    /// end_frame, so draws submitted during the frame survive).
+    pub fn update_frame_uniforms(
+        &mut self,
+        queue: &wgpu::Queue,
+        per_frame: &PerFrameUniforms,
+        per_view:  &PerViewUniforms,
+    ) {
+        queue.write_buffer(&self.per_frame_buffer, 0, bytemuck::bytes_of(per_frame));
+        queue.write_buffer(&self.per_view_buffer,  0, bytemuck::bytes_of(per_view));
+    }
+
+    /// Reset the per-draw slot cursor. Commands list is cleared by the
+    /// Renderer from its own `begin_frame` so the order of reset vs.
+    /// submit is deterministic.
+    pub fn reset_draw_slot(&mut self) {
+        self.next_draw_slot = 0;
+    }
+
+    /// Submit a draw against a compiled material. Allocates (or reuses)
+    /// a per-draw UBO slot, writes the MVP / model / tint / skin info,
+    /// and queues the command for dispatch.
+    pub fn submit_draw(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        joint_buffer: &wgpu::Buffer,
+        material: MaterialHandle,
+        mesh_handle: u64,
+        mesh_idx: usize,
+        mvp: [[f32; 4]; 4],
+        model: [[f32; 4]; 4],
+        prev_mvp: [[f32; 4]; 4],
+        tint: [f32; 4],
+        skin_info: [u32; 4],
+    ) {
+        if material == 0 || (material as usize) > self.pipelines.len() { return; }
+        let slot = self.next_draw_slot;
+        self.next_draw_slot += 1;
+        self.ensure_draw_slot(device, joint_buffer, slot);
+
+        let per_draw = PerDrawUniforms { mvp, model, prev_mvp, model_tint: tint, skin_info };
+        queue.write_buffer(&self.per_draw_buffers[slot], 0, bytemuck::bytes_of(&per_draw));
+
+        self.commands.push(MaterialDrawCommand {
+            material, mesh_handle, mesh_idx, draw_slot: slot,
+        });
+    }
+
+    fn ensure_draw_slot(
+        &mut self,
+        device: &wgpu::Device,
+        joint_buffer: &wgpu::Buffer,
+        slot: usize,
+    ) {
+        while self.per_draw_buffers.len() <= slot {
+            let buf = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("material_per_draw"),
+                size: std::mem::size_of::<PerDrawUniforms>() as u64,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("material_per_draw_bg"),
+                layout: &self.layouts.per_draw,
+                entries: &[
+                    wgpu::BindGroupEntry { binding: 0, resource: buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 1, resource: joint_buffer.as_entire_binding() },
+                ],
+            });
+            self.per_draw_buffers.push(buf);
+            self.per_draw_bgs.push(bg);
+        }
+    }
+
+    /// Dispatch all queued material draws. Caller owns the render pass;
+    /// this method binds the pipelines + groups + meshes and issues
+    /// indexed draws. `mesh_fetch` is a closure that returns
+    /// `(vertex_buffer, index_buffer, index_count)` for a given
+    /// (mesh_handle, mesh_idx) — lets the renderer hand over its
+    /// `model_gpu_cache` without this module taking a dependency on it.
+    pub fn dispatch<'pass, F>(
+        &'pass self,
+        pass: &mut wgpu::RenderPass<'pass>,
+        mut mesh_fetch: F,
+    )
+    where F: FnMut(u64, usize) -> Option<(&'pass wgpu::Buffer, &'pass wgpu::Buffer, u32)>
+    {
+        if self.commands.is_empty() { return; }
+
+        let mut last_material: MaterialHandle = 0;
+        for cmd in &self.commands {
+            if cmd.material != last_material {
+                let mat = match self.pipelines.get(cmd.material as usize - 1) {
+                    Some(Some(m)) => m,
+                    _ => continue,
+                };
+                pass.set_pipeline(&mat.pipeline);
+                pass.set_bind_group(0, &self.per_frame_bg, &[]);
+                pass.set_bind_group(1, &self.per_view_bg, &[]);
+                pass.set_bind_group(2, &self.default_per_material_bg, &[]);
+                last_material = cmd.material;
+            }
+            if let Some((vb, ib, icount)) = mesh_fetch(cmd.mesh_handle, cmd.mesh_idx) {
+                pass.set_bind_group(3, &self.per_draw_bgs[cmd.draw_slot], &[]);
+                pass.set_vertex_buffer(0, vb.slice(..));
+                pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
+                pass.draw_indexed(0..icount, 0, 0..1);
+            }
+        }
+    }
+}

--- a/native/shared/src/renderer/mod.rs
+++ b/native/shared/src/renderer/mod.rs
@@ -7,6 +7,7 @@ use shaders::*;
 pub mod shader_include;
 pub mod shader_library;
 pub mod material_pipeline;
+pub mod material_system;
 
 mod util;
 pub use util::{
@@ -1230,6 +1231,11 @@ pub struct Renderer {
     /// textures would silently point to this flat-blue normal map.
     _default_normal_texture: wgpu::Texture,
     pub default_normal_view: wgpu::TextureView,
+
+    /// Phase 1c — the new shader-ABI material draw path. Opt-in via
+    /// `compile_material` + `submit_material_draw`; existing draws are
+    /// untouched.
+    pub material_system: material_system::MaterialSystem,
 }
 
 /// Ticket 014 — re-exposed for `SceneGraph::prepare()` to allocate
@@ -4771,6 +4777,11 @@ impl Renderer {
             mapped_at_creation: false,
         });
 
+        // Phase 1c — material system: the new shader-ABI draw path.
+        // Runs alongside pipeline_3d / scene_pipeline without disturbing
+        // them; games opt in via compile_material + submit_material_draw.
+        let material_system = material_system::MaterialSystem::new(&device, &queue, &joint_buffer);
+
         Self {
             device,
             queue,
@@ -5098,6 +5109,7 @@ impl Renderer {
             prefilter_uniform_buffer,
             _default_normal_texture: default_normal_tex,
             default_normal_view,
+            material_system,
         }
     }
 
@@ -7005,6 +7017,10 @@ impl Renderer {
         self.current_uniform_idx = 0;
         self.uniform_slot_count = 0;
         self.render_mode = RenderMode::ScreenSpace;
+        // Phase 1c — clear last frame's material draws so the new
+        // frame's submissions start from an empty list.
+        self.material_system.commands.clear();
+        self.material_system.reset_draw_slot();
 
         // Write identity uniforms to slot 0 (2D uses logical points,
         // not physical pixels — see Renderer::new).
@@ -7672,6 +7688,23 @@ impl Renderer {
 
                 scene.render(&mut pass);
             }
+
+            // Phase 1c — material draws against the new ABI. Sits
+            // after the scene graph in the main HDR pass so materials
+            // compose over opaque geometry and write to the same 4-MRT
+            // attachments. Refractive/translucent materials will move
+            // to their own translucent sub-pass in Phase 2's render
+            // graph; opaque materials stay here.
+            let cache = &self.model_gpu_cache;
+            self.material_system.dispatch(&mut pass, |handle, idx| {
+                if let Some(Some(meshes)) = cache.get(&handle) {
+                    if idx < meshes.len() {
+                        let mesh = &meshes[idx];
+                        return Some((&mesh.vb, &mesh.ib, mesh.index_count));
+                    }
+                }
+                None
+            });
         }
         profiler.end("main_hdr_pass");
 
@@ -10668,5 +10701,111 @@ impl Renderer {
 
         self.custom_pipelines.push(pipeline);
         self.custom_pipelines.len() // 1-based index
+    }
+}
+
+// ============================================================
+// Phase 1c — material system (new shader-ABI draw path)
+// ============================================================
+//
+// Separate impl block so material_system's public surface on Renderer
+// stays co-located and easy to audit. All public methods either
+// compile a material, submit a draw, or sync per-frame uniforms.
+
+impl Renderer {
+    /// Compile a material from user-supplied WGSL source. Returns a
+    /// handle to use with `submit_material_draw`. The source may
+    /// `#include "material_abi.wgsl"` and any `common/*.wgsl` header.
+    pub fn compile_material(
+        &mut self, wgsl_source: &str,
+    ) -> Result<material_system::MaterialHandle, material_pipeline::MaterialCompileError> {
+        self.material_system.compile(
+            &self.device,
+            wgsl_source,
+            // Phase 1c ships opaque-only so materials render in the
+            // existing main-HDR pass without a translucent sub-pass.
+            material_pipeline::FragmentProfile::Opaque,
+            false,                         // reads_scene — phase 2
+            formats::HDR_FORMAT,
+            formats::MATERIAL_FORMAT,
+            formats::VELOCITY_FORMAT,
+            wgpu::TextureFormat::Rgba8Unorm,   // albedo_rt format
+            formats::DEPTH_FORMAT,
+        )
+    }
+
+    /// Submit a material draw against a cached mesh. `mesh_handle` is
+    /// the value returned by `cache_model_if_static` (same as the
+    /// scene pipeline's cached-model path).
+    pub fn submit_material_draw(
+        &mut self,
+        material: material_system::MaterialHandle,
+        mesh_handle: u64,
+        mesh_idx: usize,
+        position: [f32; 3],
+        scale: f32,
+        tint: [f32; 4],
+    ) {
+        let model = mat4_multiply(
+            mat4_translate(IDENTITY_MAT4, position),
+            mat4_scale(IDENTITY_MAT4, [scale, scale, scale]),
+        );
+        let mvp = mat4_multiply(self.current_vp_matrix, model);
+        self.material_system.submit_draw(
+            &self.device, &self.queue, &self.joint_buffer,
+            material, mesh_handle, mesh_idx,
+            mvp, model, mvp, tint, [0, 0, 0, 0],
+        );
+    }
+
+    /// Sync PerFrame + PerView uniforms from current renderer state.
+    /// FFI callers drive this from their frame boundary so `PerFrame.time`
+    /// reflects the real process-uptime clock.
+    pub fn material_system_begin_frame(&mut self, time_seconds: f32, delta_time: f32) {
+        let screen_w = self.surface_config.width as f32;
+        let screen_h = self.surface_config.height as f32;
+        let (rw, rh) = self.render_extent();
+        let per_frame = material_system::PerFrameUniforms {
+            time: time_seconds,
+            delta_time,
+            frame_index: self.taa_frame_index as u32,
+            _pad0: 0,
+            screen_resolution: [screen_w, screen_h],
+            render_resolution: [rw as f32, rh as f32],
+            taa_jitter: [0.0, 0.0],
+            _pad1: [0.0, 0.0],
+        };
+        let per_view = material_system::PerViewUniforms {
+            view:           self.current_view_matrix,
+            proj:           self.current_proj_matrix,
+            view_proj:      self.current_vp_matrix,
+            prev_view_proj: self.prev_vp_matrix,
+            inv_proj:       self.current_inv_proj_matrix,
+            camera_pos: [
+                self.current_camera_pos[0],
+                self.current_camera_pos[1],
+                self.current_camera_pos[2],
+                self.lighting_uniforms.camera_pos[3],
+            ],
+            camera_dir: [0.0, 0.0, -1.0, 70.0_f32.to_radians()],
+            ambient:    self.lighting_uniforms.ambient,
+            fog:        [self.fog_color[0], self.fog_color[1], self.fog_color[2], self.fog_density],
+            sun_dir:    self.lighting_uniforms.light_dir,
+            sun_color:  self.lighting_uniforms.light_color,
+            dir_light_count:   self.lighting_uniforms.dir_light_count,
+            dir_lights:        std::array::from_fn(|i| material_system::PerViewDirLight {
+                direction: self.lighting_uniforms.dir_lights[i].direction,
+                color:     self.lighting_uniforms.dir_lights[i].color,
+            }),
+            point_light_count: self.lighting_uniforms.point_light_count,
+            point_lights:      std::array::from_fn(|i| material_system::PerViewPointLight {
+                position: self.lighting_uniforms.point_lights[i].position,
+                color:    self.lighting_uniforms.point_lights[i].color,
+            }),
+            shadow_splits:   self.lighting_uniforms.shadow_cascade_splits,
+            shadow_view:     self.lighting_uniforms.shadow_view_matrix,
+            shadow_cascades: self.lighting_uniforms.shadow_cascade_vps,
+        };
+        self.material_system.update_frame_uniforms(&self.queue, &per_frame, &per_view);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,8 @@ export {
   loadModel, drawModel, unloadModel, getModelBounds, genMeshSplineRibbon,
   drawCube, drawCubeWires, drawSphere, drawSphereWires,
   drawCylinder, drawPlane, drawGrid, drawRay, genMeshCube, genMeshHeightmap,
-  loadShader, loadModelAnimation, updateModelAnimation, createMesh,
+  loadShader, compileMaterial, drawMeshWithMaterial,
+  loadModelAnimation, updateModelAnimation, createMesh,
   setAmbientLight, setDirectionalLight, setJointTest,
   loadModelAsync, stageModels, commitModel,
 } from './models/index';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,6 +17,8 @@ declare function bloom_draw_ray(ox: number, oy: number, oz: number, dx: number, 
 declare function bloom_gen_mesh_cube(w: number, h: number, d: number): number;
 declare function bloom_gen_mesh_heightmap(imageHandle: number, sizeX: number, sizeY: number, sizeZ: number): number;
 declare function bloom_load_shader(source: number): number;
+declare function bloom_compile_material(source: number): number;
+declare function bloom_draw_material(material: number, meshHandle: number, meshIdx: number, x: number, y: number, z: number, scale: number, r: number, g: number, b: number, a: number): void;
 declare function bloom_load_model_animation(path: number): number;
 declare function bloom_update_model_animation(handle: number, animIndex: number, time: number, scale: number, px: number, py: number, pz: number, rotSin: number, rotCos: number): void;
 declare function bloom_create_mesh(vertexPtr: number, vertexCount: number, indexPtr: number, indexCount: number): number;
@@ -225,6 +227,28 @@ export function genMeshHeightmap(imageHandle: number, sizeX: number, sizeY: numb
 
 export function loadShader(wgslSource: string): number {
   return bloom_load_shader(wgslSource as any);
+}
+
+/// Phase 1c — compile a material against the shader ABI in
+/// `native/shared/shaders/material_abi.wgsl`. Source may `#include`
+/// the header and common helpers. Returns a handle (>0 on success, 0
+/// on compile failure — errors log to stderr).
+export function compileMaterial(wgslSource: string): number {
+  return bloom_compile_material(wgslSource as any);
+}
+
+/// Draw a mesh with a material. `mesh` must be a Model created via
+/// `createMesh` or `loadModel`. Transform is a position + uniform
+/// scale; tint is an RGBA color multiplied into PerDraw.model_tint.
+export function drawMeshWithMaterial(
+  material: number, mesh: Model,
+  position: Vec3, scale: number, tint: Color,
+): void {
+  bloom_draw_material(
+    material, mesh.handle, 0,
+    position.x, position.y, position.z, scale,
+    tint.r, tint.g, tint.b, tint.a,
+  );
 }
 
 export function loadModelAnimation(path: string): number {


### PR DESCRIPTION
**First visible output from the new shader-ABI path.** Games can now compile a material from WGSL, submit draws against it, and see them render — end-to-end working today.

Stacks on [#33 (Phase 1b)](https://github.com/Bloom-Engine/engine/pull/33) which stacks on [#32 (Phase 1a)](https://github.com/Bloom-Engine/engine/pull/32). When #32 lands on main, rebase #33 + #34 onto it.

## What this adds

\`renderer::material_system\` owns the runtime state:
- **Per-frame UBO** with \`time\`, \`delta_time\`, \`frame_index\`, resolutions, TAA jitter
- **Per-view UBO** mirroring the existing \`LightingUniforms\` + view/proj matrices into the ABI layout
- **Default per-material bind group** — 1×1 white textures + default PBR factors + zero user params, shared by all materials that don't provide their own. Phase 5 adds the per-material overrides.
- **Per-draw UBO pool** — one \`PerDraw\` buffer + bind group per draw slot, grows 1 at a time; the pool cursor resets at \`begin_frame\`, commands are consumed at dispatch.
- **Draw command list** — accumulated during the frame, dispatched inside the main HDR pass right after the scene graph.

Rust mirrors of the ABI uniform structs (\`PerFrameUniforms\`, \`PerViewUniforms\`, \`PerDrawUniforms\`, \`MaterialFactorsUniforms\`) are \`#[repr(C)]\` / \`bytemuck::Pod\`.

Public API on \`Renderer\`:
\`\`\`rust
pub fn compile_material(&mut self, wgsl: &str) -> Result<MaterialHandle, MaterialCompileError>;
pub fn submit_material_draw(&mut self, mat, mesh_handle, mesh_idx, position, scale, tint);
pub fn material_system_begin_frame(&mut self, time: f32, delta: f32);
\`\`\`

\`max_bind_groups\` raised from 4 to 5 in macOS device creation. Metal, Vulkan, and D3D12 all support ≥7; 5 is safely portable.

FFI: \`bloom_compile_material\`, \`bloom_draw_material\`.
TS wrappers in \`bloom\`: \`compileMaterial(src)\`, \`drawMeshWithMaterial(mat, mesh, pos, scale, tint)\`.

## Smoke test

Verified in the shooter (separate PR to follow): compile a minimal ABI-compliant material, \`createMesh\` a unit cube, \`drawMeshWithMaterial\` each frame. Colour pulses with \`PerFrame.time\` — confirms the per-frame UBO plumbs through correctly.

## Phase 1c constraints (deliberate)

- **Opaque profile only.** Materials render in the existing main-HDR 4-MRT pass. Translucent/refractive materials need a separate sub-pass with a single HDR attachment — that's Phase 2's render-graph territory.
- **No per-material customisation.** Every material shares the default white-texture bind group. Per-material textures + user params land in Phase 5.
- **No \`SceneInputs\` binding.** The group 4 layout exists in the ABI but no material declares \`reads_scene = true\` yet; the scene-colour snapshot pass waits for Phase 3.
- **No hot reload.** WGSL still baked with \`include_str!\`. Phase 6.
- **Existing pipelines untouched.** \`pipeline_3d\` / \`scene_pipeline\` / sky are unchanged. Migrating them to the ABI header is deferred indefinitely — they work, and rewriting them risks regression for no visible benefit.

## Review asks

- **\`max_bind_groups = 5\`** — OK with bumping the device requirement, or should Phase 4 (SceneInputs) defer the bump until it's actually needed?
- **Dispatch site** — inside the main HDR pass, after \`scene.render()\`. Correct place, or should we move to a dedicated sub-pass even in Phase 1c?
- **Uniform clear semantics** — \`commands.clear()\` runs in \`begin_frame\` (start of frame) not \`dispatch\` (end). That way user-code submits between \`begin_drawing\` and \`end_drawing\` without depending on dispatch order. Acceptable?
- The debug prints I used to debug the begin-frame ordering bug (commands were being cleared after submission) are all removed. If you want structured profiler integration per material, that's an easy Phase 8 follow-up.