### PR TITLE
Phase 2b — extract material dispatch into own render pass

### DIFF
--- a/native/shared/src/renderer/mod.rs
+++ b/native/shared/src/renderer/mod.rs
@@ -7689,25 +7689,66 @@ impl Renderer {
 
                 scene.render(&mut pass);
             }
-
-            // Phase 1c — material draws against the new ABI. Sits
-            // after the scene graph in the main HDR pass so materials
-            // compose over opaque geometry and write to the same 4-MRT
-            // attachments. Refractive/translucent materials will move
-            // to their own translucent sub-pass in Phase 2's render
-            // graph; opaque materials stay here.
-            let cache = &self.model_gpu_cache;
-            self.material_system.dispatch(&mut pass, |handle, idx| {
-                if let Some(Some(meshes)) = cache.get(&handle) {
-                    if idx < meshes.len() {
-                        let mesh = &meshes[idx];
-                        return Some((&mesh.vb, &mesh.ib, mesh.index_count));
-                    }
-                }
-                None
-            });
         }
         profiler.end("main_hdr_pass");
+
+        // Phase 2b — material draws run in their own render pass,
+        // loading main_hdr's 4-MRT outputs + depth. Structurally the
+        // same result as the previous inline dispatch (same load-op
+        // Store, same depth-test), but the pass is now a candidate
+        // to become a render-graph node (Phase 2c) without touching
+        // the main_hdr pass body again. Skipped when the graph has
+        // no material commands this frame.
+        if !self.material_system.commands.is_empty() {
+            profiler.begin("material_pass");
+            {
+                let mat_ts = profiler.pass_timestamp_writes("material_pass");
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("bloom_material_pass"),
+                    color_attachments: &[
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: &self.hdr_rt_view,
+                            resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: &self.material_rt_view,
+                            resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: &self.velocity_rt_view,
+                            resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: &self.albedo_rt_view,
+                            resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                    ],
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: &self.depth_view,
+                        depth_ops: Some(wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store }),
+                        stencil_ops: None,
+                    }),
+                    timestamp_writes: mat_ts,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                });
+                let cache = &self.model_gpu_cache;
+                self.material_system.dispatch(&mut pass, |handle, idx| {
+                    if let Some(Some(meshes)) = cache.get(&handle) {
+                        if idx < meshes.len() {
+                            let mesh = &meshes[idx];
+                            return Some((&mesh.vb, &mesh.ib, mesh.index_count));
+                        }
+                    }
+                    None
+                });
+            }
+            profiler.end("material_pass");
+        }
 
         // ============================================================
         // SSAO: half-res GTAO sampling a hierarchical linear-depth

--- a/native/shared/src/string_header.rs
+++ b/native/shared/src/string_header.rs
@@ -13,6 +13,12 @@ pub struct StringHeader {
     pub capacity: u32,
     /// Reference hint: 0=shared, 1=unique (in-place append OK).
     pub refcount: u32,
+    /// Bit flags (STRING_FLAG_HAS_LONE_SURROGATES = 1). Added in
+    /// Perry 0.5.18x. Engines built against older Perry headers
+    /// skipped 16 bytes and ended up reading 4 bytes into the
+    /// UTF-8 data; strings crossing the FFI came back with a 4-byte
+    /// garbage prefix and trailing truncation.
+    pub flags: u32,
 }
 
 /// Extract a &str from a *const StringHeader pointer (Perry string format).

--- a/package.json
+++ b/package.json
@@ -400,7 +400,8 @@
           "lib": "libbloom_macos.a",
           "frameworks": ["Metal", "QuartzCore", "AppKit", "CoreGraphics", "CoreText",
                           "CoreFoundation", "CoreAudio", "AudioToolbox", "AVFoundation",
-                          "GameController"]
+                          "GameController"],
+          "libs": ["c++"]
         },
         "ios": {
           "crate": "native/ios/",


### PR DESCRIPTION
First concrete step toward the render graph from [RFC 0001 §2](https://github.com/Bloom-Engine/engine/pull/31). Material draws (Phase 1c) are now submitted in a dedicated render pass immediately after the main HDR pass, instead of nested inline inside it.

Stacks on [#35 (Phase 2 — render graph scheduler)](https://github.com/Bloom-Engine/engine/pull/35), which stacks on [#34 (Phase 1c)](https://github.com/Bloom-Engine/engine/pull/34).

## Rationale — why not port all ~15 passes at once?

The RFC's Phase 2 originally scoped \"port every pass in \`end_frame_with_scene\`\". Doing that in one PR is high-risk for zero visible benefit — the shooter's stable-seed SELFTEST screenshots must match pixel-identical throughout, which means every wrong LoadOp / timestamp write / missing bind group shows up as a silent regression that's hard to find.

Decomposed approach, one pass per PR:

1. **This PR**: extract the newest pass (material dispatch) out of its inline home in main_hdr into a standalone render pass. Small blast radius, easy diff. ✓
2. **Phase 2c**: wrap the new standalone pass as a \`PassNode\` and execute it through \`Graph::execute\`. No structural change, just formalises the scheduling.
3. **Phase 2d+**: port the remaining 14 passes one at a time. Each PR visual-regression-tested.

This PR is step 1: structural extraction, no graph usage yet.

## What changed

- Material dispatch moved out of the main_hdr pass body. Main_hdr now ends right after \`scene.render()\`.
- New \`bloom_material_pass\` render pass begins right after main_hdr closes. Loads all 4 MRT colour attachments (\`LoadOp::Load\`) + depth (\`LoadOp::Load\`). Stores all. Guarded on \`!commands.is_empty()\` so frames with no material draws skip the pass entirely.
- Pass body runs the exact same dispatch closure as before.

## Two fix-alongs

1. **\`StringHeader\` stale vs Perry HEAD.** Perry 0.5.18x added a \`flags: u32\` field at offset 16. Engines built against the old 16-byte layout skipped 4 bytes too few, so FFI-passed strings came back with a 4-byte garbage prefix and 4-byte trailing truncation — which manifested as WGSL parse errors on every material compile. Added \`flags: u32\` to the engine's mirror struct.
2. **\`package.json\` missing \`libs: [\"c++\"]\`** on the macOS target. Without it, any build pulling in Jolt's C++ runtime fails to link (\`__cxa_throw\`, \`__gxx_personality_v0\` unresolved). This has been pending uncommitted for a while; folded in so the shooter can build to validate.

## Verification

Shooter selftest screenshot before (Phase 1c inline dispatch) and after (Phase 2b standalone pass) look visually identical — the Phase 1c colour-pulsed cube renders in the same position, depth-tests against the same world geometry, and shows the same lighting reaction. Screenshot in the PR comments.

## Review asks

- **LoadOp::Load on all 4 MRT attachments + depth** — correct for keeping main_hdr's output intact, or is there a subtlety with \`material_rt\` (R8 unorm) / \`velocity_rt\` (R16 float) that I've missed? wgpu-validator reports clean.
- **Guard on \`!commands.is_empty()\`** — worth the branch overhead to skip the \`begin_render_pass\` call entirely when no materials are queued? An empty render pass still has a cost (attachment load/store), so the gate saves real work.
- **The two fix-alongs** — include here, or would you prefer I pull the \`StringHeader\` fix into its own tiny PR?

## Known Phase 2 limitations still open

- Graph not yet used — this PR leaves the new pass as hand-encoded code next to the hand-encoded main_hdr
- Translucent materials still need a separate sub-pass with a single HDR attachment (Phase 2c+)
- No scene-colour snapshot yet (Phase 3+)