### PR TITLE
Phase 2c — execute material pass through the render graph

### DIFF
--- a/native/shared/src/renderer/graph.rs
+++ b/native/shared/src/renderer/graph.rs
@@ -70,11 +70,14 @@ pub enum PassOutput {
 /// need; the scheduler doesn't know or care.
 ///
 /// `RunFn` takes a single untyped context argument because this module
-/// must not depend on `Renderer` (would create a module cycle). Phase
-/// 2b wires a concrete context type on the caller side.
-pub type RunFn<Ctx> = Box<dyn FnOnce(&mut Ctx) + Send>;
+/// must not depend on `Renderer` (would create a module cycle). The
+/// `'a` lifetime lets closures borrow frame-scoped data (render
+/// targets, uniform buffers) from the renderer — dropping the `Send`
+/// bound is deliberate, since graph execution is single-threaded from
+/// the caller's perspective.
+pub type RunFn<'a, Ctx> = Box<dyn FnOnce(&mut Ctx) + 'a>;
 
-pub struct PassNode<Ctx> {
+pub struct PassNode<'a, Ctx> {
     pub name:   &'static str,
     pub reads:  Vec<PassInput>,
     pub writes: Vec<PassOutput>,
@@ -85,11 +88,11 @@ pub struct PassNode<Ctx> {
     pub after:  Vec<&'static str>,
     /// Hard "run this node before X" hints. Validator rejects cycles.
     pub before: Vec<&'static str>,
-    pub run:    RunFn<Ctx>,
+    pub run:    RunFn<'a, Ctx>,
 }
 
-impl<Ctx> PassNode<Ctx> {
-    pub fn new(name: &'static str, run: RunFn<Ctx>) -> Self {
+impl<'a, Ctx> PassNode<'a, Ctx> {
+    pub fn new(name: &'static str, run: RunFn<'a, Ctx>) -> Self {
         Self {
             name, reads: Vec::new(), writes: Vec::new(),
             after: Vec::new(), before: Vec::new(),
@@ -114,8 +117,8 @@ impl<Ctx> PassNode<Ctx> {
 // Graph — a container of nodes + schedule + execute
 // =====================================================================
 
-pub struct Graph<Ctx> {
-    pub nodes: Vec<PassNode<Ctx>>,
+pub struct Graph<'a, Ctx> {
+    pub nodes: Vec<PassNode<'a, Ctx>>,
 }
 
 #[derive(Debug)]
@@ -126,9 +129,9 @@ pub enum GraphError {
     Cycle(Vec<String>),
 }
 
-impl<Ctx> Graph<Ctx> {
+impl<'a, Ctx> Graph<'a, Ctx> {
     pub fn new() -> Self { Self { nodes: Vec::new() } }
-    pub fn push(&mut self, node: PassNode<Ctx>) -> &mut Self {
+    pub fn push(&mut self, node: PassNode<'a, Ctx>) -> &mut Self {
         self.nodes.push(node); self
     }
 
@@ -143,7 +146,7 @@ impl<Ctx> Graph<Ctx> {
         let order = schedule(&self.nodes)?;
         // Drain in order. Using Option<PassNode> trick so we can take()
         // nodes out by index without panicking the Vec's geometry.
-        let mut slots: Vec<Option<PassNode<Ctx>>> = self.nodes.into_iter().map(Some).collect();
+        let mut slots: Vec<Option<PassNode<'a, Ctx>>> = self.nodes.into_iter().map(Some).collect();
         for i in order {
             let node = slots[i].take().expect("each node scheduled exactly once");
             (node.run)(ctx);
@@ -152,7 +155,7 @@ impl<Ctx> Graph<Ctx> {
     }
 }
 
-impl<Ctx> Default for Graph<Ctx> {
+impl<'a, Ctx> Default for Graph<'a, Ctx> {
     fn default() -> Self { Self::new() }
 }
 
@@ -160,7 +163,7 @@ impl<Ctx> Default for Graph<Ctx> {
 // Scheduler — topological sort (Kahn's algorithm) with hint tie-breaks
 // =====================================================================
 
-fn schedule<Ctx>(nodes: &[PassNode<Ctx>]) -> Result<Vec<usize>, GraphError> {
+fn schedule<'a, Ctx>(nodes: &[PassNode<'a, Ctx>]) -> Result<Vec<usize>, GraphError> {
     let n = nodes.len();
     if n == 0 { return Ok(Vec::new()); }
 
@@ -272,13 +275,13 @@ mod tests {
     /// Test context that records the order of pass executions.
     type TestCtx = Vec<&'static str>;
 
-    fn record(name: &'static str) -> RunFn<TestCtx> {
+    fn record(name: &'static str) -> RunFn<'static, TestCtx> {
         Box::new(move |ctx: &mut TestCtx| ctx.push(name))
     }
 
     #[test]
     fn empty_graph_runs_clean() {
-        let graph: Graph<TestCtx> = Graph::new();
+        let graph: Graph<'_, TestCtx> = Graph::new();
         let mut ctx = Vec::new();
         graph.execute(&mut ctx).unwrap();
         assert!(ctx.is_empty());
@@ -362,7 +365,7 @@ mod tests {
 
     #[test]
     fn unknown_after_is_reported() {
-        let mut graph: Graph<TestCtx> = Graph::new();
+        let mut graph: Graph<'_, TestCtx> = Graph::new();
         graph.push(PassNode::new("a", record("a"))
             .with_after(&["does_not_exist"]));
         let err = graph.schedule().unwrap_err();
@@ -377,7 +380,7 @@ mod tests {
 
     #[test]
     fn cycle_via_explicit_hints_is_rejected() {
-        let mut graph: Graph<TestCtx> = Graph::new();
+        let mut graph: Graph<'_, TestCtx> = Graph::new();
         graph.push(PassNode::new("a", record("a"))
             .with_after(&["b"]));
         graph.push(PassNode::new("b", record("b"))
@@ -396,7 +399,7 @@ mod tests {
         // A rough sketch of the Phase-2b target frame graph — shadow
         // → main_hdr → ssao → translucent → composite → swapchain —
         // proves the scheduler produces the expected order.
-        let mut graph: Graph<TestCtx> = Graph::new();
+        let mut graph: Graph<'_, TestCtx> = Graph::new();
         graph.push(PassNode::new("composite", record("composite"))
             .with_reads(&[PassInput::Transient(10)])
             // Composite is the terminal pass — explicit `after` on
@@ -448,7 +451,7 @@ mod tests {
         let c1 = counter.clone();
         let c2 = counter.clone();
 
-        let mut graph: Graph<TestCtx> = Graph::new();
+        let mut graph: Graph<'_, TestCtx> = Graph::new();
         graph.push(PassNode::new("a", Box::new(move |_ctx| {
             *c1.lock().unwrap() += 1;
         })));

--- a/native/shared/src/renderer/mod.rs
+++ b/native/shared/src/renderer/mod.rs
@@ -7692,62 +7692,101 @@ impl Renderer {
         }
         profiler.end("main_hdr_pass");
 
-        // Phase 2b — material draws run in their own render pass,
-        // loading main_hdr's 4-MRT outputs + depth. Structurally the
-        // same result as the previous inline dispatch (same load-op
-        // Store, same depth-test), but the pass is now a candidate
-        // to become a render-graph node (Phase 2c) without touching
-        // the main_hdr pass body again. Skipped when the graph has
-        // no material commands this frame.
+        // Phase 2c — schedule the material pass through the render
+        // graph. First real consumer of `renderer::graph` from #35.
+        // For now a one-node graph; later phases add more nodes
+        // (main_hdr, ssao, bloom, translucent, composite) and the
+        // graph's topological sort picks the order from read/write
+        // declarations.
+        //
+        // All per-frame borrows that the pass body needs are captured
+        // here from `&self` before we build the context that wraps
+        // `&mut encoder` + `&mut profiler`. Rust's borrow checker is
+        // happy because the immutable and mutable borrows are
+        // disjoint fields of the same struct.
         if !self.material_system.commands.is_empty() {
-            profiler.begin("material_pass");
-            {
-                let mat_ts = profiler.pass_timestamp_writes("material_pass");
-                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("bloom_material_pass"),
-                    color_attachments: &[
-                        Some(wgpu::RenderPassColorAttachment {
-                            view: &self.hdr_rt_view,
-                            resolve_target: None, depth_slice: None,
-                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
-                        }),
-                        Some(wgpu::RenderPassColorAttachment {
-                            view: &self.material_rt_view,
-                            resolve_target: None, depth_slice: None,
-                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
-                        }),
-                        Some(wgpu::RenderPassColorAttachment {
-                            view: &self.velocity_rt_view,
-                            resolve_target: None, depth_slice: None,
-                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
-                        }),
-                        Some(wgpu::RenderPassColorAttachment {
-                            view: &self.albedo_rt_view,
-                            resolve_target: None, depth_slice: None,
-                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
-                        }),
-                    ],
-                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                        view: &self.depth_view,
-                        depth_ops: Some(wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store }),
-                        stencil_ops: None,
-                    }),
-                    timestamp_writes: mat_ts,
-                    occlusion_query_set: None,
-                    multiview_mask: None,
-                });
-                let cache = &self.model_gpu_cache;
-                self.material_system.dispatch(&mut pass, |handle, idx| {
-                    if let Some(Some(meshes)) = cache.get(&handle) {
-                        if idx < meshes.len() {
-                            let mesh = &meshes[idx];
-                            return Some((&mesh.vb, &mesh.ib, mesh.index_count));
-                        }
-                    }
-                    None
-                });
+            use graph::{Graph, PassNode, PassOutput};
+
+            let hdr_rt_view       = &self.hdr_rt_view;
+            let material_rt_view  = &self.material_rt_view;
+            let velocity_rt_view  = &self.velocity_rt_view;
+            let albedo_rt_view    = &self.albedo_rt_view;
+            let depth_view        = &self.depth_view;
+            let material_system   = &self.material_system;
+            let model_gpu_cache   = &self.model_gpu_cache;
+
+            struct FrameCtx<'a> {
+                encoder:  &'a mut wgpu::CommandEncoder,
+                profiler: &'a mut crate::profiler::Profiler,
             }
-            profiler.end("material_pass");
+
+            let mut graph: Graph<FrameCtx<'_>> = Graph::new();
+            graph.push(
+                PassNode::new("material_pass", Box::new(move |ctx: &mut FrameCtx| {
+                    ctx.profiler.begin("material_pass");
+                    {
+                        let mat_ts = ctx.profiler.pass_timestamp_writes("material_pass");
+                        let mut pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("bloom_material_pass"),
+                            color_attachments: &[
+                                Some(wgpu::RenderPassColorAttachment {
+                                    view: hdr_rt_view,
+                                    resolve_target: None, depth_slice: None,
+                                    ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                                }),
+                                Some(wgpu::RenderPassColorAttachment {
+                                    view: material_rt_view,
+                                    resolve_target: None, depth_slice: None,
+                                    ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                                }),
+                                Some(wgpu::RenderPassColorAttachment {
+                                    view: velocity_rt_view,
+                                    resolve_target: None, depth_slice: None,
+                                    ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                                }),
+                                Some(wgpu::RenderPassColorAttachment {
+                                    view: albedo_rt_view,
+                                    resolve_target: None, depth_slice: None,
+                                    ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                                }),
+                            ],
+                            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                                view: depth_view,
+                                depth_ops: Some(wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store }),
+                                stencil_ops: None,
+                            }),
+                            timestamp_writes: mat_ts,
+                            occlusion_query_set: None,
+                            multiview_mask: None,
+                        });
+                        material_system.dispatch(&mut pass, |handle, idx| {
+                            if let Some(Some(meshes)) = model_gpu_cache.get(&handle) {
+                                if idx < meshes.len() {
+                                    let mesh = &meshes[idx];
+                                    return Some((&mesh.vb, &mesh.ib, mesh.index_count));
+                                }
+                            }
+                            None
+                        });
+                    }
+                    ctx.profiler.end("material_pass");
+                }))
+                // Writes HdrColor + the G-buffer so Phase 2d's scheduler
+                // can order downstream passes (SSAO, bloom, translucent)
+                // correctly once they're nodes too.
+                .with_writes(&[
+                    PassOutput::HdrColor,
+                    PassOutput::MaterialRt,
+                    PassOutput::VelocityRt,
+                    PassOutput::AlbedoRt,
+                    PassOutput::Depth,
+                ]),
+            );
+
+            let mut ctx = FrameCtx { encoder: &mut encoder, profiler: &mut *profiler };
+            if let Err(e) = graph.execute(&mut ctx) {
+                eprintln!("[graph] material_pass failed: {:?}", e);
+            }
         }
 
         // ============================================================


### PR DESCRIPTION
First real consumer of \`renderer::graph\` (from [#35](https://github.com/Bloom-Engine/engine/pull/35)). The standalone material render pass from [#36](https://github.com/Bloom-Engine/engine/pull/36) is now wrapped in a \`PassNode\` and dispatched through \`Graph::execute()\`.

One-node graph for now. Future Phase 2d+ ports land additional passes one PR at a time; the scheduler orders them from their declared reads/writes.

## What changed in mod.rs

The Phase-2b hand-encoded render pass body:

\`\`\`rust
if !self.material_system.commands.is_empty() {
    profiler.begin(\"material_pass\");
    let mut pass = encoder.begin_render_pass(&…);
    self.material_system.dispatch(&mut pass, …);
    profiler.end(\"material_pass\");
}
\`\`\`

becomes:

\`\`\`rust
if !self.material_system.commands.is_empty() {
    let hdr_rt_view = &self.hdr_rt_view;
    /* …other captures from &self… */

    struct FrameCtx<'a> {
        encoder:  &'a mut wgpu::CommandEncoder,
        profiler: &'a mut Profiler,
    }

    let mut graph: Graph<FrameCtx<'_>> = Graph::new();
    graph.push(PassNode::new(\"material_pass\", Box::new(move |ctx| {
        ctx.profiler.begin(\"material_pass\");
        let mut pass = ctx.encoder.begin_render_pass(&…);
        material_system.dispatch(&mut pass, …);
        ctx.profiler.end(\"material_pass\");
    })).with_writes(&[HdrColor, MaterialRt, VelocityRt, AlbedoRt, Depth]));

    let mut ctx = FrameCtx { encoder: &mut encoder, profiler };
    graph.execute(&mut ctx).ok();
}
\`\`\`

## Two small graph-module tweaks

- \`RunFn<'a, Ctx> = Box<dyn FnOnce(&mut Ctx) + 'a>\`. The prior \`+ Send + 'static\` bound was incompatible with closures that borrow \`&self\` renderer state (render targets, material system, model cache). Graph execution is single-threaded, so dropping \`Send\` costs nothing.
- \`Graph<'a, Ctx>\` and \`PassNode<'a, Ctx>\` pick up the \`'a\` lifetime parameter. Tests updated to \`Graph<'_, TestCtx>\`.

## Verification

- All 11 graph unit tests + 10 earlier renderer tests pass (21 total).
- Shooter's Phase 1c material cube renders identically to Phase 2b. Screenshot in PR comments.
- \`cargo check\` clean on \`bloom-shared\` and \`bloom-macos\`.

## Review asks

- **\`FrameCtx\` defined inline.** Once Phase 2d ports more passes, this struct will move to a module (probably \`render_graph::passes::FrameCtx\`) and grow more mutable fields (scene, audio, etc.). Want the eventual location now, or let it land where it's clear the struct needs to live?
- **Every captured field** (\`hdr_rt_view\`, \`material_rt_view\`, etc.) is an immutable borrow of \`&self\`. The borrow checker permits it because encoder + profiler are held disjointly through \`FrameCtx\`. This is the pattern that'll be used for every ported pass.
- **Dropped \`Send\`** from RunFn. If threaded pass execution ever becomes a goal, it has to come back. Not planned.

## Stacks on

- [#36 (Phase 2b — extract material dispatch into own pass)](https://github.com/Bloom-Engine/engine/pull/36)

## Follow-ups

- **Phase 2d+**: port real existing passes (tonemap, composite, HUD) one at a time. Visual-regression gate per PR.
- **Phase 3**: transient resource pool. Graph gains first-class \`Transient\` allocation.
- **Phase 4**: translucent bucket + \`SceneColor\` snapshot.