### PR TITLE
Phase 2d — port overlay_2d render pass to the graph

### DIFF
--- a/native/shared/src/renderer/mod.rs
+++ b/native/shared/src/renderer/mod.rs
@@ -9101,47 +9101,87 @@ impl Renderer {
         // ============================================================
         // 2D pass: immediate-mode 2D geometry on top of composited image
         // ============================================================
-        profiler.begin("overlay_2d");
+        // Phase 2d — overlay_2d ported to a graph node. Second real
+        // consumer of `renderer::graph` after material_pass. Lives in
+        // its own one-node graph here at the end of the frame because
+        // it needs to run AFTER the hand-encoded composite has
+        // written the swapchain. Phase 2e+ will merge into a single
+        // frame-wide graph as more passes port.
         if has_2d {
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("bloom_2d_pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &view,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
-            pass.set_pipeline(&self.pipeline_2d);
-            pass.set_vertex_buffer(0, self.persistent_vb_2d.slice(..));
-            pass.set_index_buffer(self.persistent_ib_2d.slice(..), wgpu::IndexFormat::Uint32);
+            use graph::{Graph, PassNode, PassOutput};
 
-            let num_calls = self.draw_calls_2d.len();
-            for i in 0..num_calls {
-                let call = &self.draw_calls_2d[i];
-                let next_start = if i + 1 < num_calls {
-                    self.draw_calls_2d[i + 1].index_start
-                } else {
-                    self.indices_2d.len() as u32
-                };
-                let count = next_start - call.index_start;
-                if count == 0 { continue; }
+            let pipeline_2d        = &self.pipeline_2d;
+            let persistent_vb_2d   = &self.persistent_vb_2d;
+            let persistent_ib_2d   = &self.persistent_ib_2d;
+            let uniform_bind_groups = &self.uniform_bind_groups;
+            let texture_bind_groups = &self.texture_bind_groups;
+            let draw_calls_2d      = &self.draw_calls_2d;
+            let indices_2d_len     = self.indices_2d.len() as u32;
+            let view_ref           = &view;
 
-                pass.set_bind_group(0, &self.uniform_bind_groups[call.uniform_idx as usize], &[]);
-                if (call.texture_idx as usize) < self.texture_bind_groups.len() {
-                    pass.set_bind_group(1, &self.texture_bind_groups[call.texture_idx as usize], &[]);
-                }
-                pass.draw_indexed(call.index_start..next_start, 0, 0..1);
+            struct OverlayCtx<'a> {
+                encoder:  &'a mut wgpu::CommandEncoder,
+                profiler: &'a mut crate::profiler::Profiler,
             }
+
+            let mut graph: Graph<OverlayCtx<'_>> = Graph::new();
+            graph.push(
+                PassNode::new("overlay_2d", Box::new(move |ctx: &mut OverlayCtx| {
+                    ctx.profiler.begin("overlay_2d");
+                    {
+                        let mut pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("bloom_2d_pass"),
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: view_ref,
+                                resolve_target: None,
+                                depth_slice: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load,
+                                    store: wgpu::StoreOp::Store,
+                                },
+                            })],
+                            depth_stencil_attachment: None,
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
+                            multiview_mask: None,
+                        });
+                        pass.set_pipeline(pipeline_2d);
+                        pass.set_vertex_buffer(0, persistent_vb_2d.slice(..));
+                        pass.set_index_buffer(persistent_ib_2d.slice(..), wgpu::IndexFormat::Uint32);
+
+                        let num_calls = draw_calls_2d.len();
+                        for i in 0..num_calls {
+                            let call = &draw_calls_2d[i];
+                            let next_start = if i + 1 < num_calls {
+                                draw_calls_2d[i + 1].index_start
+                            } else {
+                                indices_2d_len
+                            };
+                            let count = next_start - call.index_start;
+                            if count == 0 { continue; }
+
+                            pass.set_bind_group(0, &uniform_bind_groups[call.uniform_idx as usize], &[]);
+                            if (call.texture_idx as usize) < texture_bind_groups.len() {
+                                pass.set_bind_group(1, &texture_bind_groups[call.texture_idx as usize], &[]);
+                            }
+                            pass.draw_indexed(call.index_start..next_start, 0, 0..1);
+                        }
+                    }
+                    ctx.profiler.end("overlay_2d");
+                }))
+                .with_writes(&[PassOutput::Swapchain]),
+            );
+
+            let mut ctx = OverlayCtx { encoder: &mut encoder, profiler: &mut *profiler };
+            if let Err(e) = graph.execute(&mut ctx) {
+                eprintln!("[graph] overlay_2d failed: {:?}", e);
+            }
+        } else {
+            // Empty graphs are still valid — execute a no-op so the
+            // profiler bracket is symmetric with the populated path.
+            profiler.begin("overlay_2d");
+            profiler.end("overlay_2d");
         }
-        profiler.end("overlay_2d");
 
         profiler.resolve(&mut encoder);
 


### PR DESCRIPTION
Second real consumer of \`renderer::graph\` after material_pass. The 2D overlay pass (HUD text, \`drawCube\` / \`drawRect\` / \`drawCircle\` output) at the end of \`end_frame_with_scene\` is now a graph-managed \`PassNode\`.

Stacks on [#37 (Phase 2c)](https://github.com/Bloom-Engine/engine/pull/37).

## What changed

The hand-encoded 2D pass:

\`\`\`rust
profiler.begin(\"overlay_2d\");
if has_2d {
    let mut pass = encoder.begin_render_pass(&…);
    pass.set_pipeline(&self.pipeline_2d);
    /* iterate draw_calls_2d */
}
profiler.end(\"overlay_2d\");
\`\`\`

becomes:

\`\`\`rust
if has_2d {
    let pipeline_2d = &self.pipeline_2d;
    /* …other captures from &self… */

    struct OverlayCtx<'a> {
        encoder:  &'a mut wgpu::CommandEncoder,
        profiler: &'a mut Profiler,
    }

    let mut graph: Graph<OverlayCtx<'_>> = Graph::new();
    graph.push(PassNode::new(\"overlay_2d\", Box::new(move |ctx| {
        ctx.profiler.begin(\"overlay_2d\");
        let mut pass = ctx.encoder.begin_render_pass(&…);
        /* iterate draw_calls_2d using captured refs */
        ctx.profiler.end(\"overlay_2d\");
    })).with_writes(&[PassOutput::Swapchain]));

    graph.execute(&mut OverlayCtx { encoder: &mut encoder, profiler });
}
\`\`\`

## Why a separate graph (for now)

overlay_2d runs at the very end of \`end_frame_with_scene\`, after the hand-encoded composite pass has written the swapchain. material_pass runs much earlier, after main_hdr. Joining them in a single graph would mean either:

(a) Run the graph at one location → would put overlay_2d before composite (broken — composite hasn't written swapchain yet).
(b) Port composite + everything between them too → much bigger PR, defeats the incremental approach.

Phase 2e will merge into a single frame-wide graph once enough adjacent passes are ported that the scheduling becomes simpler than two separate graphs.

## Verification

- Shooter selftest screenshot identical to Phase 2c. HUD text (\"WAVE 1 IN…\", FPS diagnostic, ammo display, bottom status bar) renders correctly. Material cube still visible.
- All 21 renderer tests pass.

## Pattern emerging

Both Phase 2c and Phase 2d use the same capture-then-build-graph idiom:

1. Pre-extract \`&self.xxx\` into local immutable refs
2. Define a tiny \`Ctx\` struct with \`encoder\` + \`profiler\` mutable refs
3. \`graph.push(PassNode::new(name, Box::new(move |ctx| { … })))\`
4. \`graph.execute(&mut ctx)\`

Phase 2e+ ports more passes following this pattern. When 4+ passes share a context shape, it'll be worth lifting \`FrameCtx\` to a shared module-level struct. Inline-per-pass for now.

## Stacks on

- [#37 (Phase 2c — execute material pass through graph)](https://github.com/Bloom-Engine/engine/pull/37)