### PR TITLE
fix(jolt): disable IPO so libJolt.a links on Linux/GCC (#44)

### DIFF
--- a/native/third_party/bloom_jolt/CMakeLists.txt
+++ b/native/third_party/bloom_jolt/CMakeLists.txt
@@ -8,11 +8,18 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # ---------------------------------------------------------------------------
 # JoltPhysics build options.
-# Matches the "Distribution" flavour: no asserts, no profile, no debug renderer,
-# interprocedural optimisation on. We keep object stream off — we don't use
-# Jolt's scene serialisation (Bloom handles save/load itself).
+# Matches the "Distribution" flavour: no asserts, no profile, no debug renderer.
+# We keep object stream off — we don't use Jolt's scene serialisation (Bloom
+# handles save/load itself).
+#
+# IPO is OFF because Rust's link step on Linux/GCC routes through rust-lld,
+# which doesn't load gcc's lto-wrapper plugin. With IPO on, libJolt.a's archive
+# members are GIMPLE bitcode and rust-lld leaves their implementations
+# unresolved (undefined-symbol errors on JPH::Free, BodyManager locks, vtables,
+# etc — see issue #44). Jolt is heavily inlined via its precompiled header
+# already, so the perf delta from skipping LTO on the static archive is small.
 # ---------------------------------------------------------------------------
-set(INTERPROCEDURAL_OPTIMIZATION        ON  CACHE BOOL "" FORCE)
+set(INTERPROCEDURAL_OPTIMIZATION        OFF CACHE BOOL "" FORCE)
 set(USE_STATIC_MSVC_RUNTIME_LIBRARY     OFF CACHE BOOL "" FORCE)
 set(TARGET_UNIT_TESTS                   OFF CACHE BOOL "" FORCE)
 set(TARGET_HELLO_WORLD                  OFF CACHE BOOL "" FORCE)
@@ -21,8 +28,10 @@ set(TARGET_SAMPLES                      OFF CACHE BOOL "" FORCE)
 set(TARGET_VIEWER                       OFF CACHE BOOL "" FORCE)
 set(OBJECT_LAYER_BITS                   16  CACHE STRING "" FORCE)
 set(USE_ASSERTS                         OFF CACHE BOOL "" FORCE)
-set(PROFILE_ENABLED                     OFF CACHE BOOL "" FORCE)
+set(PROFILER_IN_DEBUG_AND_RELEASE       OFF CACHE BOOL "" FORCE)
+set(PROFILER_IN_DISTRIBUTION            OFF CACHE BOOL "" FORCE)
 set(DEBUG_RENDERER_IN_DEBUG_AND_RELEASE OFF CACHE BOOL "" FORCE)
+set(DEBUG_RENDERER_IN_DISTRIBUTION      OFF CACHE BOOL "" FORCE)
 set(CROSS_PLATFORM_DETERMINISTIC        OFF CACHE BOOL "" FORCE)
 set(FLOATING_POINT_EXCEPTIONS_ENABLED   OFF CACHE BOOL "" FORCE)
 set(DOUBLE_PRECISION                    OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Summary
- Disables `INTERPROCEDURAL_OPTIMIZATION` in `bloom_jolt`'s CMake config. Rust's link step on Linux routes through rust-lld which doesn't load gcc's lto-wrapper plugin, so `libJolt.a`'s GIMPLE-bytecode archive members leave `JPH::Free`, BodyManager locks, vtables, etc unresolved at the final link.
- Fixes a misnamed Jolt option: `PROFILE_ENABLED` is not a real Jolt CMake variable. Jolt's actual options are `PROFILER_IN_DEBUG_AND_RELEASE` and `PROFILER_IN_DISTRIBUTION`. The previous setting was a no-op, so Jolt was being built with the profiler ON despite the "no profile" intent. Same cleanup applied to `DEBUG_RENDERER_IN_DISTRIBUTION`.

## Why Linux only
macOS Apple Clang produces LTO archives that Apple's linker handles transparently — that's why local macOS builds and the macOS CI job pass. The failure mode is specific to GCC's GIMPLE bitcode + a non-GCC-driven linker, which is exactly what the Rust toolchain does on Ubuntu.

Closes #44.

## Test plan
- [x] `cargo test --release` in `native/shared/` still green on macOS (66 passed locally)
- [ ] CI's `shared-tests (ubuntu-22.04)` job goes green
- [ ] CI's `shared-tests (windows-latest)` job stays green
- [ ] CI's `build-linux` job goes green