### PR TITLE
fix(postfx): drop duplicate VertexOutput in outline_shader (#48)

### DIFF
--- a/native/shared/src/postfx.rs
+++ b/native/shared/src/postfx.rs
@@ -43,10 +43,8 @@ struct OutlineParams {
 @group(0) @binding(2) var tex_sampler: sampler;
 @group(0) @binding(3) var<uniform> params: OutlineParams;
 
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-};
+// VertexOutput is defined in FULLSCREEN_VERT — this string is concatenated
+// after it, so redefining here would be a WGSL parser error.
 
 @fragment
 fn fs_outline(in: VertexOutput) -> @location(0) vec4<f32> {


### PR DESCRIPTION
## Summary

Follow-up to #51. After that PR landed, @adevart re-tested and the bind-group validation error in \`test-gltf-watch\` was replaced by a shader compile error:

\`\`\`
Shader 'outline_shader' parsing error: redefinition of \`VertexOutput\`
\`\`\`

Both \`FULLSCREEN_VERT\` and \`OUTLINE_FRAG\` declared \`struct VertexOutput\`, which becomes a redefinition once \`format!(\"{}\\n{}\", ...)\` concatenates them in \`PostFxPipeline::new\`. This was a latent bug — naga was previously masking it behind the earlier bind-group filterable validation error that #51 fixed. Now that the bind-group error is gone, the shader-parse error surfaces and breaks the entire post-FX pipeline init on **every** example, which is why \`sponza\` started crashing on load and several others regressed.

Fix: remove the duplicate from \`OUTLINE_FRAG\`. The fragment shader picks up \`VertexOutput\` from the concatenated vertex shader prefix.

## Test plan

- [x] \`cargo check\` (\`native/macos\`)
- [x] Validated the concatenated WGSL source with \`naga 29.0.0\` CLI — \"Validation successful\"
- [ ] Re-run \`examples/test-gltf-watch\` on macOS to confirm the redefinition error is gone and outlines render
- [ ] Re-run \`examples/sponza\` on macOS to confirm it no longer crashes on load (previously regressed by the shader compile failure)