### PR TITLE
fix(android): port 60 missing bloom_* FFI exports (parity with linux/macOS) + v0.4.14

### DIFF
--- a/native/android/src/lib.rs
+++ b/native/android/src/lib.rs
@@ -1,6 +1,6 @@
 use bloom_shared::engine::EngineState;
 use bloom_shared::renderer::Renderer;
-use bloom_shared::string_header::str_from_header;
+use bloom_shared::string_header::{str_from_header, alloc_perry_string};
 use bloom_shared::audio::{parse_wav, parse_ogg, parse_mp3};
 
 use std::sync::OnceLock;
@@ -1778,3 +1778,501 @@ fn bloom_jolt_ffi_physics() -> &'static mut bloom_shared::physics_jolt::JoltPhys
 
 #[cfg(feature = "jolt")]
 bloom_shared::define_physics_ffi!();
+
+// === Android FFI parity: ported from native/linux/src/lib.rs (shared renderer/scene) ===
+// Backing statics for the ported pick/project FFI (mirror native/linux).
+static mut LAST_PROJECT: (f64, f64) = (0.0, 0.0);
+static mut LAST_PICK: Option<bloom_shared::picking::PickResult> = None;
+
+#[no_mangle]
+pub extern "C" fn bloom_add_directional_light(
+    dx: f64, dy: f64, dz: f64,
+    r: f64, g: f64, b: f64,
+    intensity: f64,
+) {
+    engine().renderer.add_directional_light(
+        dx as f32, dy as f32, dz as f32,
+        r as f32, g as f32, b as f32,
+        intensity as f32,
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_add_point_light(
+    x: f64, y: f64, z: f64, range: f64,
+    r: f64, g: f64, b: f64,
+    intensity: f64,
+) {
+    engine().renderer.add_point_light(
+        x as f32, y as f32, z as f32, range as f32,
+        r as f32, g as f32, b as f32,
+        intensity as f32,
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_begin_texture_mode(_handle: f64) {
+    // Stub: no-op until GPU render-to-texture is wired.
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_disable_postfx() {
+    engine().postfx = None;
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_disable_shadows() {
+    engine().renderer.shadow_map.disable();
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_dump_shadow_map(path_ptr: *const u8) {
+    let path = str_from_header(path_ptr).to_string();
+    engine().renderer.dump_shadow_map(&path);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_enable_postfx() {
+    let eng = engine();
+    let w = eng.renderer.width();
+    let h = eng.renderer.height();
+    let fmt = eng.renderer.surface_format();
+    eng.postfx = Some(bloom_shared::postfx::PostFxPipeline::new(
+        &eng.renderer.device, w, h, fmt,
+    ));
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_enable_shadows() {
+    engine().renderer.shadow_map.enable();
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_end_texture_mode() {
+    // Stub: no-op.
+}
+
+// Q9: Generate a ribbon mesh along a Catmull-Rom spline.
+#[no_mangle]
+pub extern "C" fn bloom_gen_mesh_spline_ribbon(points_ptr: *const u8, point_count: f64, widths_ptr: *const u8, width_count: f64) -> f64 {
+    let n = point_count as usize;
+    let wn = width_count as usize;
+    let points = unsafe { std::slice::from_raw_parts(points_ptr as *const f32, n * 3) };
+    let widths = unsafe { std::slice::from_raw_parts(widths_ptr as *const f32, wn) };
+    engine().models.gen_mesh_spline_ribbon(points, widths)
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_get_render_texture_texture(handle: f64) -> f64 {
+    engine().textures.get_render_texture_texture(handle)
+}
+
+// Q1: Render texture FFI (stub — GPU implementation deferred).
+#[no_mangle]
+pub extern "C" fn bloom_load_render_texture(width: f64, height: f64) -> f64 {
+    engine().textures.load_render_texture(width as u32, height as u32)
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_distance() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.distance as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_handle() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.handle).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_normal_x() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.normal[0] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_normal_y() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.normal[1] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_normal_z() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.normal[2] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_x() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.point[0] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_y() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.point[1] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_pick_hit_z() -> f64 {
+    unsafe { LAST_PICK.as_ref().map(|r| r.point[2] as f64).unwrap_or(0.0) }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_postfx_set_hovered(handle: f64) {
+    if let Some(pfx) = &mut engine().postfx {
+        pfx.set_hovered(handle);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_postfx_set_outline_color(r: f64, g: f64, b: f64, a: f64) {
+    if let Some(pfx) = &mut engine().postfx {
+        pfx.outline_params.color_selected = [r as f32, g as f32, b as f32, a as f32];
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_postfx_set_outline_thickness(thickness: f64) {
+    if let Some(pfx) = &mut engine().postfx {
+        pfx.outline_params.thickness[0] = thickness as f32;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_postfx_set_selected(handle: f64) {
+    if let Some(pfx) = &mut engine().postfx {
+        if handle == 0.0 {
+            pfx.set_selected(Vec::new());
+        } else {
+            pfx.set_selected(vec![handle]);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_profiler_frame_history() -> *const u8 {
+    let hist = engine().profiler.frame_history();
+    let mut s = String::with_capacity(hist.len() * 24);
+    for (cpu, gpu) in &hist {
+        s.push_str(&format!("{:.2}|{:.2}\n", cpu, gpu));
+    }
+    alloc_perry_string(&s)
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_profiler_overlay_text() -> *const u8 {
+    let snap = engine().profiler.snapshot();
+    let mut s = String::with_capacity(snap.len() * 48);
+    for (label, cpu, gpu) in &snap {
+        s.push_str(label);
+        s.push('|');
+        s.push_str(&format!("{:.2}", cpu));
+        s.push('|');
+        match gpu {
+            Some(g) => s.push_str(&format!("{:.2}", g)),
+            None    => s.push_str("-1"),
+        }
+        s.push('\n');
+    }
+    alloc_perry_string(&s)
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_project_screen_y() -> f64 {
+    unsafe { LAST_PROJECT.1 }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_project_to_screen(wx: f64, wy: f64, wz: f64) -> f64 {
+    let eng = engine();
+    let vp = eng.renderer.vp_matrix();
+    let w = eng.renderer.width() as f32;
+    let h = eng.renderer.height() as f32;
+
+    let x = wx as f32;
+    let y = wy as f32;
+    let z = wz as f32;
+    let clip_x = vp[0][0]*x + vp[1][0]*y + vp[2][0]*z + vp[3][0];
+    let clip_y = vp[0][1]*x + vp[1][1]*y + vp[2][1]*z + vp[3][1];
+    let clip_w = vp[0][3]*x + vp[1][3]*y + vp[2][3]*z + vp[3][3];
+
+    if clip_w <= 0.0 {
+        unsafe { LAST_PROJECT = (-9999.0, -9999.0); }
+        return -9999.0;
+    }
+
+    let ndc_x = clip_x / clip_w;
+    let ndc_y = clip_y / clip_w;
+    let screen_x = ((ndc_x + 1.0) * 0.5 * w) as f64;
+    let screen_y = ((1.0 - ndc_y) * 0.5 * h) as f64;
+
+    unsafe { LAST_PROJECT = (screen_x, screen_y); }
+    screen_x
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_register_frame_callback(priority: f64, callback: extern "C" fn(f64)) -> f64 {
+    engine().frame_callbacks.register(priority as i32, callback) as f64
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_attach_model(node_handle: f64, model_handle: f64, mesh_index: f64) {
+    let eng = engine();
+    let mi = mesh_index as usize;
+
+    let model_data = match eng.models.models.get(model_handle) {
+        Some(md) => md,
+        None => return,
+    };
+    if mi >= model_data.meshes.len() { return; }
+    let mesh = &model_data.meshes[mi];
+
+    let vertices = mesh.vertices.clone();
+    let indices = mesh.indices.clone();
+    let base_color_tex = mesh.texture_idx;
+    let normal_tex = mesh.normal_texture_idx;
+    let mr_tex = mesh.metallic_roughness_texture_idx;
+    let emissive_tex = mesh.emissive_texture_idx;
+    let emissive_factor = mesh.emissive_factor;
+    eng.scene.update_geometry(node_handle, vertices, indices);
+
+    if let Some(tex_idx) = base_color_tex {
+        eng.scene.set_material_texture(node_handle, tex_idx);
+    }
+    if let Some(tex_idx) = normal_tex {
+        eng.scene.set_material_normal_texture(node_handle, tex_idx);
+    }
+    if let Some(tex_idx) = mr_tex {
+        eng.scene.set_material_metallic_roughness_texture(node_handle, tex_idx);
+    }
+    if let Some(tex_idx) = emissive_tex {
+        eng.scene.set_material_emissive_texture(node_handle, tex_idx);
+    }
+    eng.scene.set_material_emissive_factor(
+        node_handle,
+        emissive_factor[0],
+        emissive_factor[1],
+        emissive_factor[2],
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_create_node() -> f64 {
+    engine().scene.create_node()
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_destroy_node(handle: f64) {
+    engine().scene.destroy_node(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_extrude_polygon(
+    handle: f64,
+    polygon_ptr: *const f64,
+    polygon_count: f64,
+    depth: f64,
+) {
+    if polygon_ptr.is_null() { return; }
+    let n = polygon_count as usize;
+    let polygon = unsafe { std::slice::from_raw_parts(polygon_ptr, n * 2) };
+
+    let geo = bloom_shared::geometry::extrude_polygon(polygon, &[], depth);
+    engine().scene.update_geometry(handle, geo.vertices, geo.indices);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_max_x(handle: f64) -> f64 { engine().scene.get_bounds(handle).1[0] as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_max_y(handle: f64) -> f64 { engine().scene.get_bounds(handle).1[1] as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_max_z(handle: f64) -> f64 { engine().scene.get_bounds(handle).1[2] as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_min_x(handle: f64) -> f64 { engine().scene.get_bounds(handle).0[0] as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_min_y(handle: f64) -> f64 { engine().scene.get_bounds(handle).0[1] as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_bounds_min_z(handle: f64) -> f64 { engine().scene.get_bounds(handle).0[2] as f64 }
+
+// Scene graph QoL — Q4/Q5/Q6/Q7
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_transform(handle: f64, index: f64) -> f64 {
+    let mat = engine().scene.get_transform(handle);
+    let i = index as usize;
+    let col = i / 4;
+    let row = i % 4;
+    if col < 4 && row < 4 { mat[col][row] as f64 } else { 0.0 }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_get_user_data(handle: f64) -> f64 { engine().scene.get_user_data(handle) as f64 }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_node_count() -> f64 {
+    engine().scene.node_count() as f64
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_node_index_count(handle: f64) -> f64 {
+    match engine().scene.nodes.get(handle) {
+        Some(node) => node.indices.len() as f64,
+        None => -1.0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_node_vertex_count(handle: f64) -> f64 {
+    match engine().scene.nodes.get(handle) {
+        Some(node) => node.vertices.len() as f64,
+        None => -1.0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_pick(screen_x: f64, screen_y: f64) -> f64 {
+    let eng = engine();
+    let inv_vp = eng.renderer.inverse_vp_matrix();
+    let cam_pos = eng.renderer.camera_pos();
+    let w = eng.renderer.width() as f32;
+    let h = eng.renderer.height() as f32;
+
+    let (origin, direction) = bloom_shared::picking::screen_to_ray(
+        screen_x as f32, screen_y as f32,
+        w, h, &inv_vp, &cam_pos,
+    );
+
+    let result = bloom_shared::picking::raycast_scene(&eng.scene, &origin, &direction);
+    let hit = result.hit;
+    unsafe { LAST_PICK = Some(result); }
+    if hit { 1.0 } else { 0.0 }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_cast_shadow(handle: f64, cast: f64) {
+    engine().scene.set_cast_shadow(handle, cast != 0.0);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_material_color(handle: f64, r: f64, g: f64, b: f64, a: f64) {
+    engine().scene.set_material_color(handle, r as f32, g as f32, b as f32, a as f32);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_material_pbr(handle: f64, roughness: f64, metalness: f64) {
+    engine().scene.set_material_pbr(handle, roughness as f32, metalness as f32);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_material_texture(handle: f64, texture_idx: f64) {
+    engine().scene.set_material_texture(handle, texture_idx as u32);
+}
+
+// Q8: Set a water material on a scene node (translucent tint, low roughness).
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_material_water(handle: f64, wave_amp: f64, wave_speed: f64, r: f64, g: f64, b: f64, a: f64) {
+    engine().scene.set_material_water(handle, wave_amp as f32, wave_speed as f32, r as f32, g as f32, b as f32, a as f32);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_parent(handle: f64, parent: f64) {
+    engine().scene.set_parent(handle, parent);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_receive_shadow(handle: f64, receive: f64) {
+    engine().scene.set_receive_shadow(handle, receive != 0.0);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_transform(handle: f64, mat_ptr: *const f64) {
+    if mat_ptr.is_null() { return; }
+    let slice = unsafe { std::slice::from_raw_parts(mat_ptr, 16) };
+    let mut mat = [[0.0f32; 4]; 4];
+    for col in 0..4 {
+        for row in 0..4 {
+            mat[col][row] = slice[col * 4 + row] as f32;
+        }
+    }
+    engine().scene.set_transform(handle, mat);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_user_data(handle: f64, data: f64) { engine().scene.set_user_data(handle, data as i64); }
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_set_visible(handle: f64, visible: f64) {
+    engine().scene.set_visible(handle, visible != 0.0);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_subtract_box(
+    handle: f64,
+    min_x: f64, min_y: f64, min_z: f64,
+    max_x: f64, max_y: f64, max_z: f64,
+) {
+    let eng = engine();
+    if let Some(node) = eng.scene.nodes.get(handle) {
+        let current = bloom_shared::geometry::GeometryData {
+            vertices: node.vertices.clone(),
+            indices: node.indices.clone(),
+        };
+        let result = bloom_shared::geometry::subtract_box(
+            &current,
+            [min_x as f32, min_y as f32, min_z as f32],
+            [max_x as f32, max_y as f32, max_z as f32],
+        );
+        eng.scene.update_geometry(handle, result.vertices, result.indices);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_scene_update_geometry(
+    handle: f64,
+    vert_ptr: *const f64,
+    vert_count: f64,
+    idx_ptr: *const f64,
+    idx_count: f64,
+) {
+    if vert_ptr.is_null() || idx_ptr.is_null() { return; }
+    let nv = vert_count as usize;
+    let ni = idx_count as usize;
+
+    let vert_floats = unsafe { std::slice::from_raw_parts(vert_ptr, nv * 12) };
+    let idx_floats = unsafe { std::slice::from_raw_parts(idx_ptr, ni) };
+
+    let mut vertices = Vec::with_capacity(nv);
+    for i in 0..nv {
+        let base = i * 12;
+        vertices.push(bloom_shared::renderer::Vertex3D {
+            position: [vert_floats[base] as f32, vert_floats[base+1] as f32, vert_floats[base+2] as f32],
+            normal: [vert_floats[base+3] as f32, vert_floats[base+4] as f32, vert_floats[base+5] as f32],
+            color: [vert_floats[base+6] as f32, vert_floats[base+7] as f32, vert_floats[base+8] as f32, vert_floats[base+9] as f32],
+            uv: [vert_floats[base+10] as f32, vert_floats[base+11] as f32],
+            joints: [0.0; 4],
+            weights: [0.0; 4],
+            tangent: [0.0; 4],
+        });
+    }
+
+    let indices: Vec<u32> = idx_floats.iter().map(|&v| v as u32).collect();
+
+    engine().scene.update_geometry(handle, vertices, indices);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_splat_impulse(x: f64, z: f64, radius: f64, strength: f64) {
+    engine().renderer.impulse_field.submit_splat(
+        x as f32, z as f32, radius as f32, strength as f32,
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_unload_render_texture(handle: f64) {
+    engine().textures.unload_render_texture(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn bloom_unregister_frame_callback(id: f64) {
+    engine().frame_callbacks.unregister(id as u64);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomengine/engine",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Bloom Engine: native TypeScript game engine compiled by Perry",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -94,458 +94,3345 @@
     "nativeLibrary": {
       "module": "@bloomengine/engine",
       "functions": [
-        { "name": "bloom_init_window",              "params": ["f64", "f64", "string", "f64"],                              "returns": "void" },
-        { "name": "bloom_close_window",             "params": [],                                                        "returns": "void" },
-        { "name": "bloom_window_should_close",      "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_begin_drawing",            "params": [],                                                        "returns": "void" },
-        { "name": "bloom_end_drawing",              "params": [],                                                        "returns": "void" },
-        { "name": "bloom_take_screenshot",          "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_clear_background",         "params": ["f64", "f64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_set_env_clear_from_hdr",   "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_set_target_fps",           "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_direct_2d_mode",       "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_get_delta_time",           "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_fps",                  "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_screen_width",         "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_screen_height",        "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_is_key_pressed",           "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_key_down",              "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_key_released",          "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_mouse_x",              "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_mouse_y",              "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_is_mouse_button_pressed",  "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_mouse_button_down",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_mouse_button_released", "params": ["f64"],                                                   "returns": "f64"  },
-
-        { "name": "bloom_draw_line",                "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],  "returns": "void" },
-        { "name": "bloom_draw_rect",                "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],         "returns": "void" },
-        { "name": "bloom_draw_rect_lines",          "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_circle",              "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],                "returns": "void" },
-        { "name": "bloom_draw_circle_lines",        "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],                "returns": "void" },
-        { "name": "bloom_draw_triangle",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],  "returns": "void" },
-        { "name": "bloom_draw_poly",                "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],  "returns": "void" },
-
-        { "name": "bloom_draw_text",                "params": ["string", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],  "returns": "void" },
-        { "name": "bloom_measure_text",             "params": ["string", "f64"],                                            "returns": "f64"  },
-        { "name": "bloom_load_font",                "params": ["string", "f64"],                                            "returns": "f64"  },
-        { "name": "bloom_unload_font",              "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_draw_text_ex",             "params": ["f64", "string", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_measure_text_ex",          "params": ["f64", "string", "f64", "f64"],                              "returns": "f64"  },
-
-        { "name": "bloom_init_audio",               "params": [],                                                        "returns": "void" },
-        { "name": "bloom_close_audio",              "params": [],                                                        "returns": "void" },
-        { "name": "bloom_load_sound",               "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_play_sound",               "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_stop_sound",               "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_sound_volume",         "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_set_master_volume",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_play_sound_3d",            "params": ["f64", "f64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_set_listener_position",    "params": ["f64", "f64", "f64", "f64", "f64", "f64"],               "returns": "void" },
-
-        { "name": "bloom_load_texture",             "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_unload_texture",           "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_draw_texture",             "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],         "returns": "void" },
-        { "name": "bloom_draw_texture_rec",         "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_texture_pro",         "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_get_texture_width",        "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_texture_height",       "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_load_image",               "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_image_resize",             "params": ["f64", "f64", "f64"],                                     "returns": "void" },
-        { "name": "bloom_image_crop",               "params": ["f64", "f64", "f64", "f64", "f64"],                       "returns": "void" },
-        { "name": "bloom_image_flip_h",             "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_image_flip_v",             "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_load_texture_from_image",  "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_gen_texture_mipmaps",      "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_texture_filter",      "params": ["f64", "f64"],                                            "returns": "void" },
-
-        { "name": "bloom_begin_mode_2d",            "params": ["f64", "f64", "f64", "f64", "f64", "f64"],               "returns": "void" },
-        { "name": "bloom_end_mode_2d",              "params": [],                                                        "returns": "void" },
-        { "name": "bloom_begin_mode_3d",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_end_mode_3d",              "params": [],                                                        "returns": "void" },
-
-        { "name": "bloom_draw_cube",                "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_cube_wires",          "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_sphere",              "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_sphere_wires",        "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_cylinder",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_plane",               "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_grid",                "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_draw_ray",                 "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-
-        { "name": "bloom_load_model",               "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_draw_model",               "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_draw_model_rotated",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],         "returns": "void" },
-        { "name": "bloom_unload_model",             "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_gen_mesh_cube",            "params": ["f64", "f64", "f64"],                                     "returns": "f64"  },
-        { "name": "bloom_gen_mesh_heightmap",       "params": ["f64", "f64", "f64", "f64"],                              "returns": "f64"  },
-        { "name": "bloom_load_shader",              "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_compile_material",         "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_compile_material_refractive", "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_compile_material_transparent","params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_compile_material_additive",   "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_compile_material_cutout",     "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_compile_material_instanced",  "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_create_instance_buffer",      "params": ["i64", "f64"],                                       "returns": "f64"  },
-        { "name": "bloom_submit_material_draw_instanced", "params": ["f64", "f64", "f64", "f64", "f64"],               "returns": "void" },
-        { "name": "bloom_destroy_instance_buffer",     "params": ["f64"],                                              "returns": "void" },
-        { "name": "bloom_create_planar_reflection",    "params": ["f64", "f64", "f64", "f64", "f64"],                  "returns": "f64"  },
-        { "name": "bloom_set_material_reflection_probe", "params": ["f64", "f64"],                                     "returns": "void" },
-        { "name": "bloom_create_texture_array",        "params": ["i64", "f64", "f64", "f64", "f64"],                  "returns": "f64"  },
-        { "name": "bloom_create_texture_array_ex",     "params": ["i64", "f64", "f64", "f64", "f64", "f64", "f64"],    "returns": "f64"  },
-        { "name": "bloom_set_material_texture_array",  "params": ["f64", "f64", "f64"],                                "returns": "void" },
-        { "name": "bloom_set_material_shading_model",  "params": ["f64", "f64"],                                       "returns": "void" },
-        { "name": "bloom_set_material_foliage",        "params": ["f64", "f64", "f64", "f64", "f64", "f64"],           "returns": "void" },
-        { "name": "bloom_set_post_pass",               "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_clear_post_pass",             "params": [],                                                   "returns": "void" },
-        { "name": "bloom_add_post_pass",               "params": ["string"],                                              "returns": "f64"  },
-        { "name": "bloom_clear_all_post_passes",       "params": [],                                                   "returns": "void" },
-        { "name": "bloom_draw_material",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_load_model_animation",   "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_update_model_animation",  "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-        { "name": "bloom_create_mesh",             "params": ["i64", "f64", "i64", "f64"],                             "returns": "f64"  },
-        { "name": "bloom_set_joint_test",          "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_set_ambient_light",       "params": ["f64", "f64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_set_directional_light",   "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],        "returns": "void" },
-        { "name": "bloom_set_procedural_sky",      "params": ["f64", "f64", "f64", "f64"],                            "returns": "void" },
-        { "name": "bloom_set_sun_direction",       "params": ["f64", "f64", "f64", "f64"],                            "returns": "void" },
-        { "name": "bloom_set_fog",                 "params": ["f64", "f64", "f64", "f64", "f64", "f64"],               "returns": "void" },
-        { "name": "bloom_set_chromatic_aberration","params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_vignette",            "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_set_film_grain",          "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_sun_shafts",          "params": ["f64", "f64", "f64", "f64", "f64"],                      "returns": "void" },
-        { "name": "bloom_set_auto_exposure",       "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_taa_enabled",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_render_scale",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_get_render_scale",        "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_set_upscale_mode",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_cas_strength",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_get_physical_width",      "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_physical_height",     "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_set_auto_resolution",     "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_set_manual_exposure",     "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_env_intensity",       "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssgi_enabled",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssgi_intensity",      "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssgi_radius",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_dof",                 "params": ["f64", "f64", "f64"],                                    "returns": "void" },
-        { "name": "bloom_set_quality_preset",      "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_shadows_enabled",     "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_shadows_always_fresh", "params": ["f64"],                                                  "returns": "void" },
-        { "name": "bloom_set_bloom_enabled",       "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssao_enabled",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssao_intensity",      "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_ssao_radius",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_wind",                "params": ["f64", "f64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_set_ssr_enabled",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_motion_blur_enabled", "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_sss_enabled",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_profiler_enabled",    "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_get_profiler_frame_cpu_us","params": [],                                                       "returns": "f64"  },
-        { "name": "bloom_get_profiler_frame_gpu_us","params": [],                                                       "returns": "f64"  },
-        { "name": "bloom_print_profiler_summary",  "params": [],                                                        "returns": "void" },
-        { "name": "bloom_get_model_mesh_count",    "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_material_count","params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_inject_key_down",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_inject_key_up",           "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_inject_gamepad_axis",     "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_inject_gamepad_button_down","params": ["f64"],                                                 "returns": "void" },
-        { "name": "bloom_inject_gamepad_button_up","params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_get_platform",            "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_language",            "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_is_any_input_pressed",    "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_crown_rotation",      "params": [],                                                        "returns": "f64"  },
-
-        { "name": "bloom_load_music",               "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_play_music",               "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_stop_music",               "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_update_music_stream",      "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_music_volume",         "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_is_music_playing",         "params": ["f64"],                                                   "returns": "f64"  },
-
-        { "name": "bloom_is_gamepad_available",     "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_gamepad_axis",         "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_gamepad_button_pressed", "params": ["f64"],                                                  "returns": "f64"  },
-        { "name": "bloom_is_gamepad_button_down",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_is_gamepad_button_released","params": ["f64"],                                                  "returns": "f64"  },
-        { "name": "bloom_get_gamepad_axis_count",   "params": [],                                                        "returns": "f64"  },
-
-        { "name": "bloom_toggle_fullscreen",        "params": [],                                                        "returns": "void" },
-        { "name": "bloom_set_window_title",         "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_set_window_icon",          "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_disable_cursor",           "params": [],                                                        "returns": "void" },
-        { "name": "bloom_enable_cursor",            "params": [],                                                        "returns": "void" },
-        { "name": "bloom_get_mouse_delta_x",        "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_mouse_delta_y",        "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_mouse_wheel",          "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_char_pressed",        "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_min_x",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_min_y",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_min_z",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_max_x",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_max_y",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_model_bounds_max_z",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_write_file",               "params": ["string", "string"],                                            "returns": "f64"  },
-        { "name": "bloom_file_exists",              "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_read_file",                "params": ["string"],                                                   "returns": "string"  },
-        { "name": "bloom_get_touch_x",              "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_touch_y",              "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_get_touch_count",          "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_get_time",                 "params": [],                                                        "returns": "f64"  },
-
-        { "name": "bloom_register_frame_callback",     "params": ["f64", "i64"],                                            "returns": "f64"  },
-        { "name": "bloom_unregister_frame_callback",   "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_run_game",                    "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_add_directional_light",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],        "returns": "void" },
-        { "name": "bloom_add_point_light",             "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "void" },
-
-        { "name": "bloom_scene_create_node",           "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_scene_destroy_node",          "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_scene_set_visible",           "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_set_cast_shadow",       "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_set_receive_shadow",    "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_set_parent",            "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_set_transform",         "params": ["f64", "i64"],                                            "returns": "void" },
-        { "name": "bloom_scene_update_geometry",       "params": ["f64", "i64", "f64", "i64", "f64"],                       "returns": "void" },
-        { "name": "bloom_scene_set_material_color",    "params": ["f64", "f64", "f64", "f64", "f64"],                       "returns": "void" },
-        { "name": "bloom_scene_set_material_pbr",      "params": ["f64", "f64", "f64"],                                     "returns": "void" },
-        { "name": "bloom_scene_set_material_texture",  "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_node_count",            "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_scene_node_vertex_count",  "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_node_index_count",   "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_set_cursor_shape",            "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_set_clipboard_text",          "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_get_clipboard_text",          "params": [],                                                        "returns": "string"  },
-        { "name": "bloom_open_file_dialog",            "params": ["string", "string"],                                            "returns": "string"  },
-        { "name": "bloom_save_file_dialog",            "params": ["string", "string"],                                            "returns": "string"  },
-        { "name": "bloom_scene_pick_all",              "params": ["f64", "f64", "f64"],                                     "returns": "f64"  },
-        { "name": "bloom_pick_all_handle",             "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_pick_all_distance",           "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_set_material_water",    "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],        "returns": "void" },
-        { "name": "bloom_gen_mesh_spline_ribbon",      "params": ["i64", "f64", "i64", "f64"],                              "returns": "f64"  },
-        { "name": "bloom_load_render_texture",         "params": ["f64", "f64"],                                            "returns": "f64"  },
-        { "name": "bloom_unload_render_texture",       "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_begin_texture_mode",          "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_end_texture_mode",            "params": [],                                                        "returns": "void" },
-        { "name": "bloom_get_render_texture_texture",  "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_transform",         "params": ["f64", "f64"],                                            "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_min_x",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_min_y",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_min_z",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_max_x",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_max_y",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_get_bounds_max_z",     "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_set_user_data",        "params": ["f64", "f64"],                                            "returns": "void" },
-        { "name": "bloom_scene_get_user_data",        "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_scene_extrude_polygon",      "params": ["f64", "i64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_scene_subtract_box",         "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],        "returns": "void" },
-        { "name": "bloom_enable_shadows",             "params": [],                                                        "returns": "void" },
-        { "name": "bloom_disable_shadows",            "params": [],                                                        "returns": "void" },
-        { "name": "bloom_dump_shadow_map",           "params": ["string"],                                                   "returns": "void" },
-        { "name": "bloom_scene_attach_model",         "params": ["f64", "f64", "f64"],                                     "returns": "void" },
-        { "name": "bloom_enable_postfx",              "params": [],                                                        "returns": "void" },
-        { "name": "bloom_disable_postfx",             "params": [],                                                        "returns": "void" },
-        { "name": "bloom_postfx_set_selected",        "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_postfx_set_hovered",         "params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_postfx_set_outline_color",   "params": ["f64", "f64", "f64", "f64"],                              "returns": "void" },
-        { "name": "bloom_postfx_set_outline_thickness","params": ["f64"],                                                   "returns": "void" },
-        { "name": "bloom_project_to_screen",          "params": ["f64", "f64", "f64"],                                     "returns": "f64"  },
-        { "name": "bloom_project_screen_y",           "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_scene_pick",                "params": ["f64", "f64"],                                            "returns": "f64"  },
-        { "name": "bloom_pick_hit_handle",           "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_distance",         "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_x",                "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_y",                "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_z",                "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_normal_x",         "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_normal_y",         "params": [],                                                        "returns": "f64"  },
-        { "name": "bloom_pick_hit_normal_z",         "params": [],                                                        "returns": "f64"  },
-
-        { "name": "bloom_stage_texture",              "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_stage_model",                "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_stage_sound",                "params": ["string"],                                                   "returns": "f64"  },
-        { "name": "bloom_commit_texture",             "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_commit_model",               "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_commit_sound",               "params": ["f64"],                                                   "returns": "f64"  },
-        { "name": "bloom_commit_music",               "params": ["f64"],                                                   "returns": "f64"  },
-
-        { "name": "bloom_physics_create_world",           "params": ["f64", "f64", "f64", "f64", "f64"],                                                                 "returns": "f64"  },
-        { "name": "bloom_physics_destroy_world",          "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_set_gravity",            "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_get_gravity",            "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_optimize_broadphase",    "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_step",                   "params": ["f64", "f64", "f64"],                                                                                "returns": "void" },
-        { "name": "bloom_physics_set_layer_collides",     "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_get_layer_collides",     "params": ["f64", "f64", "f64"],                                                                                "returns": "f64"  },
-        { "name": "bloom_physics_body_count",             "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_active_body_count",      "params": ["f64"],                                                                                              "returns": "f64"  },
-
-        { "name": "bloom_physics_shape_box",              "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "f64"  },
-        { "name": "bloom_physics_shape_sphere",           "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_shape_capsule",          "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_shape_cylinder",         "params": ["f64", "f64", "f64"],                                                                                "returns": "f64"  },
-        { "name": "bloom_physics_shape_scaled",           "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "f64"  },
-        { "name": "bloom_physics_shape_offset_com",       "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "f64"  },
-        { "name": "bloom_physics_shape_release",          "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_scratch_reset",          "params": [],                                                                                                   "returns": "void" },
-        { "name": "bloom_physics_scratch_push_f32",       "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_scratch_push_u32",       "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_shape_convex_hull",      "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_shape_mesh",             "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_shape_heightfield",      "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                             "returns": "f64"  },
-        { "name": "bloom_physics_compound_begin",         "params": [],                                                                                                   "returns": "void" },
-        { "name": "bloom_physics_compound_add_child",     "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                             "returns": "void" },
-        { "name": "bloom_physics_compound_end",           "params": [],                                                                                                   "returns": "f64"  },
-        { "name": "bloom_physics_shape_bounds",           "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_shape_volume",           "params": ["f64"],                                                                                              "returns": "f64"  },
-
-        { "name": "bloom_physics_body_create",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                        "returns": "f64"  },
-        { "name": "bloom_physics_body_destroy",           "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_body_activate",          "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_body_deactivate",        "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_body_is_active",         "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_body_is_valid",          "params": ["f64"],                                                                                              "returns": "f64"  },
-
-        { "name": "bloom_physics_body_get_position",      "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_body_get_rotation",      "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_body_set_position",      "params": ["f64", "f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_body_set_rotation",      "params": ["f64", "f64", "f64", "f64", "f64", "f64"],                                                           "returns": "void" },
-        { "name": "bloom_physics_body_set_transform",     "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                      "returns": "void" },
-        { "name": "bloom_physics_body_move_kinematic",    "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                      "returns": "void" },
-
-        { "name": "bloom_physics_body_get_linear_velocity", "params": ["f64", "f64"],                                                                                     "returns": "f64"  },
-        { "name": "bloom_physics_body_get_angular_velocity","params": ["f64", "f64"],                                                                                     "returns": "f64"  },
-        { "name": "bloom_physics_body_get_point_velocity",  "params": ["f64", "f64", "f64", "f64", "f64"],                                                                "returns": "f64"  },
-        { "name": "bloom_physics_body_set_linear_velocity", "params": ["f64", "f64", "f64", "f64"],                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_angular_velocity","params": ["f64", "f64", "f64", "f64"],                                                                       "returns": "void" },
-
-        { "name": "bloom_physics_body_add_force",         "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_body_add_impulse",       "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_body_add_torque",        "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_body_add_angular_impulse","params": ["f64", "f64", "f64", "f64"],                                                                        "returns": "void" },
-        { "name": "bloom_physics_body_add_force_at",      "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                                    "returns": "void" },
-        { "name": "bloom_physics_body_add_impulse_at",    "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                                    "returns": "void" },
-
-        { "name": "bloom_physics_body_set_friction",      "params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_restitution",   "params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_linear_damping","params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_angular_damping","params": ["f64", "f64"],                                                                                      "returns": "void" },
-        { "name": "bloom_physics_body_set_gravity_factor","params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_ccd",           "params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_motion_type",   "params": ["f64", "f64", "f64"],                                                                                "returns": "void" },
-        { "name": "bloom_physics_body_set_object_layer",  "params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_is_sensor",     "params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_allow_sleeping","params": ["f64", "f64"],                                                                                       "returns": "void" },
-        { "name": "bloom_physics_body_set_shape",         "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_body_lock_rotation_axes", "params": ["f64", "f64", "f64", "f64"],                                                                        "returns": "void" },
-        { "name": "bloom_physics_body_lock_translation_axes","params": ["f64", "f64", "f64", "f64"],                                                                      "returns": "void" },
-
-        { "name": "bloom_physics_body_get_mass",          "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_body_get_friction",      "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_body_get_restitution",   "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_body_get_object_layer",  "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_body_set_user_data",     "params": ["f64", "f64", "f64"],                                                                                "returns": "void" },
-        { "name": "bloom_physics_body_get_user_data",     "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-
-        { "name": "bloom_physics_raycast",                "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                      "returns": "f64"  },
-        { "name": "bloom_physics_raycast_all",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                               "returns": "f64"  },
-        { "name": "bloom_physics_ray_hit_count",          "params": [],                                                                                                   "returns": "f64"  },
-        { "name": "bloom_physics_ray_hit_body",           "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_ray_hit_axis",           "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_ray_hit_fraction",       "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_ray_hit_sub_shape",      "params": ["f64"],                                                                                              "returns": "f64"  },
-
-        { "name": "bloom_physics_overlap_sphere",         "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                                    "returns": "f64"  },
-        { "name": "bloom_physics_overlap_point",          "params": ["f64", "f64", "f64", "f64", "f64", "f64"],                                                           "returns": "f64"  },
-        { "name": "bloom_physics_overlap_box",            "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],          "returns": "f64"  },
-        { "name": "bloom_physics_overlap_body",           "params": ["f64"],                                                                                              "returns": "f64"  },
-
-        { "name": "bloom_physics_constraint_fixed",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                      "returns": "f64"  },
-        { "name": "bloom_physics_constraint_point",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                                      "returns": "f64"  },
-        { "name": "bloom_physics_constraint_hinge",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],   "returns": "f64"  },
-        { "name": "bloom_physics_constraint_slider",      "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],   "returns": "f64"  },
-        { "name": "bloom_physics_constraint_distance",    "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"],                        "returns": "f64"  },
-        { "name": "bloom_physics_constraint_destroy",     "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_constraint_set_enabled", "params": ["f64", "f64"],                                                                                       "returns": "void" },
-
-        { "name": "bloom_physics_contact_count",          "params": [],                                                                                                   "returns": "f64"  },
-        { "name": "bloom_physics_contact_field",          "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_clear_contacts",         "params": ["f64"],                                                                                              "returns": "void" },
-
-        { "name": "bloom_physics_character_create",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "f64"  },
-        { "name": "bloom_physics_character_destroy",      "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_character_update",       "params": ["f64", "f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_character_get_position", "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_character_get_rotation", "params": ["f64", "f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_character_set_position", "params": ["f64", "f64", "f64", "f64"],                                                                         "returns": "void" },
-        { "name": "bloom_physics_character_set_rotation", "params": ["f64", "f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_character_get_linear_velocity", "params": ["f64", "f64"],                                                                                "returns": "f64"  },
-        { "name": "bloom_physics_character_set_linear_velocity", "params": ["f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_character_get_ground_state",    "params": ["f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_character_get_ground_normal",   "params": ["f64", "f64"],                                                                                "returns": "f64"  },
-        { "name": "bloom_physics_character_get_ground_position", "params": ["f64", "f64"],                                                                                "returns": "f64"  },
-        { "name": "bloom_physics_character_get_ground_body",     "params": ["f64"],                                                                                       "returns": "f64"  },
-        { "name": "bloom_physics_character_set_shape",           "params": ["f64", "f64"],                                                                                "returns": "void" },
-
-        { "name": "bloom_physics_soft_body_create",       "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "f64" },
-        { "name": "bloom_physics_soft_body_vertex_count", "params": ["f64"],                                                                                              "returns": "f64" },
-        { "name": "bloom_physics_soft_body_get_vertex",   "params": ["f64", "f64", "f64"],                                                                                "returns": "f64" },
-        { "name": "bloom_physics_soft_body_set_vertex",   "params": ["f64", "f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_soft_body_set_vertex_inv_mass", "params": ["f64", "f64", "f64"],                                                                         "returns": "void" },
-
-        { "name": "bloom_physics_vehicle_create",        "params": ["f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64", "f64"], "returns": "f64"  },
-        { "name": "bloom_physics_vehicle_destroy",       "params": ["f64"],                                                                                              "returns": "void" },
-        { "name": "bloom_physics_vehicle_get_chassis",   "params": ["f64"],                                                                                              "returns": "f64"  },
-        { "name": "bloom_physics_vehicle_set_input",     "params": ["f64", "f64", "f64", "f64", "f64"],                                                                  "returns": "void" },
-        { "name": "bloom_physics_vehicle_get_wheel_transform", "params": ["f64", "f64", "f64"],                                                                          "returns": "f64"  },
-        { "name": "bloom_physics_vehicle_get_engine_rpm", "params": ["f64"],                                                                                             "returns": "f64"  },
-        { "name": "bloom_physics_vehicle_get_wheel_angular_velocity", "params": ["f64", "f64"],                                                                          "returns": "f64"  }
+        {
+          "name": "bloom_init_window",
+          "params": [
+            "f64",
+            "f64",
+            "string",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_close_window",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_window_should_close",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_begin_drawing",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_end_drawing",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_take_screenshot",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_clear_background",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_env_clear_from_hdr",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_target_fps",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_direct_2d_mode",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_delta_time",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_fps",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_screen_width",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_screen_height",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_key_pressed",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_key_down",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_key_released",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_mouse_x",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_mouse_y",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_mouse_button_pressed",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_mouse_button_down",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_mouse_button_released",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_draw_line",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_rect",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_rect_lines",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_circle",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_circle_lines",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_triangle",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_poly",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_text",
+          "params": [
+            "string",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_measure_text",
+          "params": [
+            "string",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_load_font",
+          "params": [
+            "string",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_unload_font",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_text_ex",
+          "params": [
+            "f64",
+            "string",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_measure_text_ex",
+          "params": [
+            "f64",
+            "string",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_init_audio",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_close_audio",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_load_sound",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_play_sound",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_stop_sound",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_sound_volume",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_master_volume",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_play_sound_3d",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_listener_position",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_load_texture",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_unload_texture",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_texture",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_texture_rec",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_texture_pro",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_texture_width",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_texture_height",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_load_image",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_image_resize",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_image_crop",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_image_flip_h",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_image_flip_v",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_load_texture_from_image",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_gen_texture_mipmaps",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_texture_filter",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_begin_mode_2d",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_end_mode_2d",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_begin_mode_3d",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_end_mode_3d",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_cube",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_cube_wires",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_sphere",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_sphere_wires",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_cylinder",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_plane",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_grid",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_ray",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_load_model",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_draw_model",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_model_rotated",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_unload_model",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_gen_mesh_cube",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_gen_mesh_heightmap",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_load_shader",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material_refractive",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material_transparent",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material_additive",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material_cutout",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_compile_material_instanced",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_create_instance_buffer",
+          "params": [
+            "i64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_submit_material_draw_instanced",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_destroy_instance_buffer",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_create_planar_reflection",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_material_reflection_probe",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_create_texture_array",
+          "params": [
+            "i64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_create_texture_array_ex",
+          "params": [
+            "i64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_material_texture_array",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_material_shading_model",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_material_foliage",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_post_pass",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_clear_post_pass",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_add_post_pass",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_clear_all_post_passes",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_draw_material",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_load_model_animation",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_update_model_animation",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_create_mesh",
+          "params": [
+            "i64",
+            "f64",
+            "i64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_joint_test",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ambient_light",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_directional_light",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_procedural_sky",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_sun_direction",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_fog",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_chromatic_aberration",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_vignette",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_film_grain",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_sun_shafts",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_auto_exposure",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_taa_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_render_scale",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_render_scale",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_upscale_mode",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_cas_strength",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_physical_width",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_physical_height",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_auto_resolution",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_manual_exposure",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_env_intensity",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssgi_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssgi_intensity",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssgi_radius",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_dof",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_quality_preset",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_shadows_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_shadows_always_fresh",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_bloom_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssao_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssao_intensity",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssao_radius",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_wind",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_ssr_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_motion_blur_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_sss_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_profiler_enabled",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_profiler_frame_cpu_us",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_profiler_frame_gpu_us",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_print_profiler_summary",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_model_mesh_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_material_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_inject_key_down",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_inject_key_up",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_inject_gamepad_axis",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_inject_gamepad_button_down",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_inject_gamepad_button_up",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_platform",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_language",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_any_input_pressed",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_crown_rotation",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_load_music",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_play_music",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_stop_music",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_update_music_stream",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_music_volume",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_is_music_playing",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_gamepad_available",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_gamepad_axis",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_gamepad_button_pressed",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_gamepad_button_down",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_is_gamepad_button_released",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_gamepad_axis_count",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_toggle_fullscreen",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_window_title",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_window_icon",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_disable_cursor",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_enable_cursor",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_mouse_delta_x",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_mouse_delta_y",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_mouse_wheel",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_char_pressed",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_min_x",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_min_y",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_min_z",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_max_x",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_max_y",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_model_bounds_max_z",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_write_file",
+          "params": [
+            "string",
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_file_exists",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_read_file",
+          "params": [
+            "string"
+          ],
+          "returns": "string"
+        },
+        {
+          "name": "bloom_get_touch_x",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_touch_y",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_touch_count",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_get_time",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_register_frame_callback",
+          "params": [
+            "f64",
+            "i64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_unregister_frame_callback",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_run_game",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_add_directional_light",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_add_point_light",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_create_node",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_destroy_node",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_visible",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_cast_shadow",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_receive_shadow",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_parent",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_transform",
+          "params": [
+            "f64",
+            "i64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_update_geometry",
+          "params": [
+            "f64",
+            "i64",
+            "f64",
+            "i64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_material_color",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_material_pbr",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_set_material_texture",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_node_count",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_node_vertex_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_node_index_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_set_cursor_shape",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_set_clipboard_text",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_clipboard_text",
+          "params": [],
+          "returns": "string"
+        },
+        {
+          "name": "bloom_open_file_dialog",
+          "params": [
+            "string",
+            "string"
+          ],
+          "returns": "string"
+        },
+        {
+          "name": "bloom_save_file_dialog",
+          "params": [
+            "string",
+            "string"
+          ],
+          "returns": "string"
+        },
+        {
+          "name": "bloom_scene_pick_all",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_all_handle",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_all_distance",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_set_material_water",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_gen_mesh_spline_ribbon",
+          "params": [
+            "i64",
+            "f64",
+            "i64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_load_render_texture",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_unload_render_texture",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_begin_texture_mode",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_end_texture_mode",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_get_render_texture_texture",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_transform",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_min_x",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_min_y",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_min_z",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_max_x",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_max_y",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_get_bounds_max_z",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_set_user_data",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_get_user_data",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_extrude_polygon",
+          "params": [
+            "f64",
+            "i64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_subtract_box",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_enable_shadows",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_disable_shadows",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_dump_shadow_map",
+          "params": [
+            "string"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_scene_attach_model",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_enable_postfx",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_disable_postfx",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_postfx_set_selected",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_postfx_set_hovered",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_postfx_set_outline_color",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_postfx_set_outline_thickness",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_project_to_screen",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_project_screen_y",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_scene_pick",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_handle",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_distance",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_x",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_y",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_z",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_normal_x",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_normal_y",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_pick_hit_normal_z",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_stage_texture",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_stage_model",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_stage_sound",
+          "params": [
+            "string"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_commit_texture",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_commit_model",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_commit_sound",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_commit_music",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_create_world",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_destroy_world",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_set_gravity",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_get_gravity",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_optimize_broadphase",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_step",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_set_layer_collides",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_get_layer_collides",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_active_body_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_box",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_sphere",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_capsule",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_cylinder",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_scaled",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_offset_com",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_release",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_scratch_reset",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_scratch_push_f32",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_scratch_push_u32",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_shape_convex_hull",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_mesh",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_heightfield",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_compound_begin",
+          "params": [],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_compound_add_child",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_compound_end",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_bounds",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_shape_volume",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_create",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_destroy",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_activate",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_deactivate",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_is_active",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_is_valid",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_position",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_rotation",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_set_position",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_rotation",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_transform",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_move_kinematic",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_get_linear_velocity",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_angular_velocity",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_point_velocity",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_set_linear_velocity",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_angular_velocity",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_force",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_impulse",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_torque",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_angular_impulse",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_force_at",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_add_impulse_at",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_friction",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_restitution",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_linear_damping",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_angular_damping",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_gravity_factor",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_ccd",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_motion_type",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_object_layer",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_is_sensor",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_allow_sleeping",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_set_shape",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_lock_rotation_axes",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_lock_translation_axes",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_get_mass",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_friction",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_restitution",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_get_object_layer",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_body_set_user_data",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_body_get_user_data",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_raycast",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_raycast_all",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_ray_hit_count",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_ray_hit_body",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_ray_hit_axis",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_ray_hit_fraction",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_ray_hit_sub_shape",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_overlap_sphere",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_overlap_point",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_overlap_box",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_overlap_body",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_fixed",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_point",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_hinge",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_slider",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_distance",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_constraint_destroy",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_constraint_set_enabled",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_contact_count",
+          "params": [],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_contact_field",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_clear_contacts",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_create",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_destroy",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_update",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_get_position",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_get_rotation",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_set_position",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_set_rotation",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_get_linear_velocity",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_set_linear_velocity",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_character_get_ground_state",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_get_ground_normal",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_get_ground_position",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_get_ground_body",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_character_set_shape",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_soft_body_create",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_soft_body_vertex_count",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_soft_body_get_vertex",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_soft_body_set_vertex",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_soft_body_set_vertex_inv_mass",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_vehicle_create",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_vehicle_destroy",
+          "params": [
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_vehicle_get_chassis",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_vehicle_set_input",
+          "params": [
+            "f64",
+            "f64",
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "void"
+        },
+        {
+          "name": "bloom_physics_vehicle_get_wheel_transform",
+          "params": [
+            "f64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_vehicle_get_engine_rpm",
+          "params": [
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
+          "name": "bloom_physics_vehicle_get_wheel_angular_velocity",
+          "params": [
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        }
       ],
       "targets": {
         "macos": {
           "crate": "native/macos/",
           "lib": "libbloom_macos.a",
-          "frameworks": ["Metal", "QuartzCore", "AppKit", "CoreGraphics", "CoreText",
-                          "CoreFoundation", "CoreAudio", "AudioToolbox", "AVFoundation",
-                          "GameController"],
-          "libs": ["c++"]
+          "frameworks": [
+            "Metal",
+            "QuartzCore",
+            "AppKit",
+            "CoreGraphics",
+            "CoreText",
+            "CoreFoundation",
+            "CoreAudio",
+            "AudioToolbox",
+            "AVFoundation",
+            "GameController"
+          ],
+          "libs": [
+            "c++"
+          ]
         },
         "ios": {
           "crate": "native/ios/",
           "lib": "libbloom_ios.a",
-          "frameworks": ["Metal", "QuartzCore", "UIKit", "CoreGraphics", "CoreText",
-                          "CoreFoundation", "CoreAudio", "AudioToolbox", "AVFoundation",
-                          "GameController"]
+          "frameworks": [
+            "Metal",
+            "QuartzCore",
+            "UIKit",
+            "CoreGraphics",
+            "CoreText",
+            "CoreFoundation",
+            "CoreAudio",
+            "AudioToolbox",
+            "AVFoundation",
+            "GameController"
+          ]
         },
         "tvos": {
           "crate": "native/tvos/",
           "lib": "libbloom_tvos.a",
-          "frameworks": ["Metal", "QuartzCore", "UIKit", "CoreGraphics", "CoreText",
-                          "CoreFoundation", "CoreAudio", "AudioToolbox", "AVFoundation",
-                          "GameController"],
-          "libs": ["c++"]
+          "frameworks": [
+            "Metal",
+            "QuartzCore",
+            "UIKit",
+            "CoreGraphics",
+            "CoreText",
+            "CoreFoundation",
+            "CoreAudio",
+            "AudioToolbox",
+            "AVFoundation",
+            "GameController"
+          ],
+          "libs": [
+            "c++"
+          ]
         },
         "watchos": {
           "crate": "native/watchos/",
           "lib": "libbloom_watchos.a",
-          "frameworks": ["WatchKit", "Foundation", "CoreGraphics", "QuartzCore", "SwiftUI", "SceneKit", "AVFoundation"],
-          "swift_sources": ["native/watchos/src/BloomWatchApp.swift", "native/watchos/src/BloomWatchAudio.swift"],
-          "metal_sources": ["native/watchos/shaders/bloom_postfx.metal"]
+          "frameworks": [
+            "WatchKit",
+            "Foundation",
+            "CoreGraphics",
+            "QuartzCore",
+            "SwiftUI",
+            "SceneKit",
+            "AVFoundation"
+          ],
+          "swift_sources": [
+            "native/watchos/src/BloomWatchApp.swift",
+            "native/watchos/src/BloomWatchAudio.swift"
+          ],
+          "metal_sources": [
+            "native/watchos/shaders/bloom_postfx.metal"
+          ]
         },
         "windows": {
           "crate": "native/windows/",
           "lib": "bloom_windows.lib",
-          "libs": ["user32", "gdi32", "ole32", "shell32", "d3d12", "dxgi", "dxguid", "xinput", "opengl32", "d3dcompiler"]
+          "libs": [
+            "user32",
+            "gdi32",
+            "ole32",
+            "shell32",
+            "d3d12",
+            "dxgi",
+            "dxguid",
+            "xinput",
+            "opengl32",
+            "d3dcompiler"
+          ]
         },
         "linux": {
           "crate": "native/linux/",
           "lib": "libbloom_linux.a",
-          "libs": ["stdc++"],
-          "pkgConfig": ["x11", "xi", "alsa"]
+          "libs": [
+            "stdc++"
+          ],
+          "pkgConfig": [
+            "x11",
+            "xi",
+            "alsa"
+          ]
         },
         "android": {
           "crate": "native/android/",
           "lib": "libbloom_android.a",
-          "libs": ["android", "log", "c++_static", "c++abi", "OpenSLES"]
+          "libs": [
+            "android",
+            "log",
+            "c++_static",
+            "c++abi",
+            "OpenSLES"
+          ]
         },
         "web": {
           "crate": "native/web/",


### PR DESCRIPTION
## Problem
`bloom-android` exported **209** `bloom_*` FFI functions vs **265** on linux/macOS — **60 missing** (scene graph, lighting, post-FX, picking, render-textures, frame callbacks, `bloom_splat_impulse`).

Perry statically links the engine into `libperry_app.so`, and the engine's shared TS (`core/index.ts`) references these symbols, so every Perry-built Android app crashed at launch:

```
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "bloom_splat_impulse"
  referenced by ".../lib/arm64-v8a/libperry_app.so"
  at com.perry.app.PerryActivity.startNative
```

## Fix
- Ported the 60 implementations verbatim from `native/linux/src/lib.rs` (Android shares the same wgpu renderer + scene crate, so no behavioural change vs linux).
- Added the two backing statics they use: `LAST_PICK`, `LAST_PROJECT`.
- Bumped to **v0.4.14**.

## Verification
`cargo check --target aarch64-linux-android` passes (only pre-existing unused-var warnings). A Perry Android build against this lib loads + runs instead of crashing on `dlopen`.

Mirrors #58-era parity work and 4af46ac (tvOS parity).