### PR TITLE
fix(android): raise buffer-binding limits to adapter max (joint_bg crash) + v0.4.15

### DIFF
--- a/native/android/src/lib.rs
+++ b/native/android/src/lib.rs
@@ -184,8 +184,21 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
         } else {
             wgpu::ExperimentalFeatures::disabled()
         };
+        let adapter_limits = adapter.limits();
         let mut required_limits = wgpu::Limits::downlevel_defaults()
-            .using_resolution(adapter.limits());
+            .using_resolution(adapter_limits.clone());
+        // The renderer's `joint_bg` binds a 64KB uniform buffer, but
+        // downlevel_defaults caps uniform-buffer bindings at 16KB, so
+        // create_bind_group panics on mobile GPUs (e.g. Adreno) with
+        // "range 65536 exceeds max_*_buffer_binding_size limit 16384". Raise the
+        // buffer-binding sizes (and bind-group count) to the adapter's maximum;
+        // these are guaranteed-supported and match the desktop limits.
+        required_limits.max_uniform_buffer_binding_size =
+            adapter_limits.max_uniform_buffer_binding_size;
+        required_limits.max_storage_buffer_binding_size =
+            adapter_limits.max_storage_buffer_binding_size;
+        required_limits.max_bind_groups =
+            required_limits.max_bind_groups.max(5).min(adapter_limits.max_bind_groups);
         if required_features.intersects(rt_mask) {
             required_limits = required_limits
                 .using_minimum_supported_acceleration_structure_values();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomengine/engine",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Bloom Engine: native TypeScript game engine compiled by Perry",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Problem
Perry-built Android apps crash at init with SIGABRT:
```
wgpu error: Validation Error
  In Device::create_bind_group, label = 'joint_bg'
    Buffer binding 0 range 65536 exceeds max_*_buffer_binding_size limit 16384
```
The Android device is created from `Limits::downlevel_defaults()` (uniform binding cap **16KB**) merged with `.using_resolution()` (which only updates texture-dimension limits). The renderer's joint-matrix bind group binds a **64KB** uniform buffer. Desktop uses `Limits::default()` (64KB), so it never reproduced there.

## Fix
After the downlevel merge, raise `max_uniform_buffer_binding_size`, `max_storage_buffer_binding_size`, and `max_bind_groups` to the **adapter's reported max** (guaranteed-supported; matches desktop limits).

## Verification
`cargo check --target aarch64-linux-android` passes. Confirmed end-to-end: a Perry Android build of Bloom Jump now **launches and renders on a physical Adreno device** instead of aborting at init (root-caused via an on-device panic→logcat hook; the failing R8/gralloc lines in logcat were unrelated driver noise).

Bumps to v0.4.15.