### PR TITLE
feat(attach): host-surface attach path on all platforms (PerryTS/perry#5519)

### DIFF
--- a/native/android/src/lib.rs
+++ b/native/android/src/lib.rs
@@ -262,6 +262,62 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
     }
 }
 
+/// Attach the engine to a host-owned `ANativeWindow*` instead of pulling
+/// it from the global set by `bloom_android_set_native_window`
+/// (PerryTS/perry#5519). `handle` is the `ANativeWindow*` the host
+/// (Perry UI's `BloomView`, backed by a `SurfaceView`/`TextureView`)
+/// owns; `width`/`height` are the surface size in physical pixels.
+/// Returns 1.0 on success, 0.0 on a null/invalid handle or surface
+/// bring-up failure. Idempotent once attached.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0;
+    }
+    let window = handle as *mut libc::c_void;
+    let Some(win_nn) = std::ptr::NonNull::new(window) else {
+        return 0.0;
+    };
+    // Hold a reference for as long as the engine renders into it.
+    unsafe {
+        ANativeWindow_acquire(window);
+        NATIVE_WINDOW = window;
+    }
+    let target = {
+        let h = raw_window_handle::AndroidNdkWindowHandle::new(win_nn);
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(raw_window_handle::RawDisplayHandle::Android(
+                raw_window_handle::AndroidDisplayHandle::new(),
+            )),
+            raw_window_handle: raw_window_handle::RawWindowHandle::AndroidNdk(h),
+        }
+    };
+    match unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::VULKAN | wgpu::Backends::GL,
+                logical_w: (width as u32).max(1),
+                logical_h: (height as u32).max(1),
+                physical_w: (width as u32).max(1),
+                physical_h: (height as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::Srgb,
+            },
+        )
+    } {
+        Ok(es) => {
+            unsafe {
+                let _ = ENGINE.set(es);
+            }
+            1.0
+        }
+        Err(_) => 0.0,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe {

--- a/native/android/src/lib.rs
+++ b/native/android/src/lib.rs
@@ -318,6 +318,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     }
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe {

--- a/native/ios/src/lib.rs
+++ b/native/ios/src/lib.rs
@@ -783,6 +783,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     }
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/ios/src/lib.rs
+++ b/native/ios/src/lib.rs
@@ -733,6 +733,56 @@ pub extern "C" fn bloom_init_window(_width: f64, _height: f64, title_ptr: *const
     }
 }
 
+/// Attach the engine to a host-owned `UIView*` instead of creating its
+/// own UIWindow (PerryTS/perry#5519). `handle` is the raw `UIView*` the
+/// host (Perry UI's `BloomView`) owns; `width`/`height` are its size in
+/// points. Returns 1.0 on success, 0.0 on a null/invalid handle or if
+/// surface bring-up failed. Idempotent once attached.
+///
+/// HiDPI: callers wanting full backing resolution should pass the pixel
+/// size (points × `UIScreen.scale`); this path uses `width`/`height` as
+/// the drawable size directly.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0;
+    }
+    let Some(view_nn) = std::ptr::NonNull::new(handle as *mut c_void) else {
+        return 0.0;
+    };
+    let target = {
+        let h = UiKitWindowHandle::new(view_nn);
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(RawDisplayHandle::UiKit(UiKitDisplayHandle::new())),
+            raw_window_handle: RawWindowHandle::UiKit(h),
+        }
+    };
+    match unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::METAL,
+                logical_w: width as u32,
+                logical_h: height as u32,
+                physical_w: (width as u32).max(1),
+                physical_h: (height as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::Srgb,
+            },
+        )
+    } {
+        Ok(es) => {
+            unsafe {
+                let _ = ENGINE.set(es);
+            }
+            1.0
+        }
+        Err(_) => 0.0,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/linux/src/lib.rs
+++ b/native/linux/src/lib.rs
@@ -649,6 +649,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     0.0
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {}
 

--- a/native/linux/src/lib.rs
+++ b/native/linux/src/lib.rs
@@ -632,6 +632,23 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
     panic!("bloom-linux can only run on Linux");
 }
 
+/// Attach the engine to a host-owned surface (PerryTS/perry#5519).
+///
+/// Not yet wired on Linux: Perry UI's GTK4 `BloomView` hands out a
+/// `GtkWidget*`, and turning that into a wgpu surface needs the widget
+/// realized/mapped and its `GdkSurface` bridged to an X11 `Window` (or a
+/// Wayland `wl_surface`) — the GTK4 dmabuf/`GtkGLArea` path the issue
+/// calls out as the larger follow-up. Until that lands this returns 0.0
+/// (failure) so hosts fall back to the windowed `bloom_init_window`
+/// path. The symbol exists so the FFI surface is uniform across
+/// platforms (the shared bring-up is `bloom_shared::attach::attach_engine`,
+/// already used by the Apple/Android/Windows attach paths).
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    let _ = (handle, width, height);
+    0.0
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {}
 

--- a/native/macos/src/lib.rs
+++ b/native/macos/src/lib.rs
@@ -7,7 +7,6 @@
 #![allow(static_mut_refs)]
 
 use bloom_shared::engine::EngineState;
-use bloom_shared::renderer::Renderer;
 use bloom_shared::string_header::{str_from_header, alloc_perry_string};
 
 use objc2::rc::Retained;
@@ -349,125 +348,43 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
         let _: () = msg_send![&content_view, setWantsLayer: true];
     }
 
-    // Create wgpu surface and renderer
-    // wgpu expects the NSView pointer (not NSWindow) for AppKit
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::METAL,
-        ..wgpu::InstanceDescriptor::new_without_display_handle()
-    });
-
-    let surface = unsafe {
-        let view_ptr = Retained::as_ptr(&content_view) as *mut std::ffi::c_void;
-        let handle = AppKitWindowHandle::new(
-            std::ptr::NonNull::new(view_ptr).unwrap()
-        );
-        let raw = RawWindowHandle::AppKit(handle);
-        instance.create_surface_unsafe(wgpu::SurfaceTargetUnsafe::RawHandle {
-            raw_display_handle: Some(raw_window_handle::RawDisplayHandle::AppKit(raw_window_handle::AppKitDisplayHandle::new())),
-            raw_window_handle: raw,
-        }).expect("Failed to create surface")
-    };
-
-    let adapter = pollster_block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        compatible_surface: Some(&surface),
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        ..Default::default()
-    })).expect("No adapter found");
-
-    // Request TIMESTAMP_QUERY when the adapter supports it so the profiler
-    // can collect GPU timings. It's optional — profiler falls back to CPU
-    // only when the feature isn't available.
-    let supported = adapter.features();
-    let mut required_features = wgpu::Features::empty();
-    if supported.contains(wgpu::Features::TIMESTAMP_QUERY) {
-        required_features |= wgpu::Features::TIMESTAMP_QUERY;
-    }
-    // Cooked BC7 textures (bloom-cook) upload compressed when the
-    // adapter has BC support; without it they CPU-decode at load.
-    if supported.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
-        required_features |= wgpu::Features::TEXTURE_COMPRESSION_BC;
-    }
-    // Ticket 007b: request ray-query + BLAS/TLAS where the adapter
-    // supports both (Apple Silicon Metal, DXR 1.1, VK_KHR_ray_query).
-    // `BLOOM_FORCE_SW_GI=1` forces the SW fallback for testing parity
-    // with non-RT adapters.
-    let force_sw_gi = std::env::var("BLOOM_FORCE_SW_GI")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    // wgpu 29 gates BLAS/TLAS creation + ray-query WGSL on a single
-    // feature bit; there's no separate "acceleration structure" flag.
-    let rt_mask = wgpu::Features::EXPERIMENTAL_RAY_QUERY;
-    if !force_sw_gi && supported.contains(rt_mask) {
-        required_features |= rt_mask;
-    }
-    // wgpu 29 requires an explicit `ExperimentalFeatures::enabled()` token
-    // when requesting any `EXPERIMENTAL_*` feature (ray query in our case).
-    // The token is constructed through an `unsafe` API acknowledging that
-    // experimental paths may hit undefined behavior — Apple Silicon's Metal
-    // ray-query path has been stable in wgpu releases since v25 so we're
-    // willing to take that risk here.
-    let experimental_features = if required_features.intersects(rt_mask) {
-        unsafe { wgpu::ExperimentalFeatures::enabled() }
-    } else {
-        wgpu::ExperimentalFeatures::disabled()
-    };
-    // Acceleration-structure limits default to 0 when RT is disabled.
-    // `using_minimum_supported_acceleration_structure_values` bumps
-    // them to the spec minimums (2^24 BLAS geometries / TLAS instances,
-    // etc.) whenever ray query was granted.
-    let mut required_limits = wgpu::Limits::default();
-    // Phase 1c: the material ABI declares 5 bind groups (PerFrame,
-    // PerView, PerMaterial, PerDraw, SceneInputs). wgpu's default
-    // limit is 4. Metal / Vulkan / D3D12 support at least 7, so 5 is
-    // safely within every real backend's capabilities.
-    required_limits.max_bind_groups = 5;
-    if required_features.intersects(rt_mask) {
-        required_limits = required_limits
-            .using_minimum_supported_acceleration_structure_values();
-    }
-    let (device, queue) = pollster_block_on(adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            label: Some("bloom_device"),
-            required_features,
-            required_limits,
-            experimental_features,
-            ..Default::default()
-        },
-    )).expect("Failed to create device");
-
-    let surface_caps = surface.get_capabilities(&adapter);
-    let format = surface_caps.formats.iter()
-        .find(|f| f.is_srgb())
-        .copied()
-        .unwrap_or(surface_caps.formats[0]);
-
-    // Retina/HiDPI: AppKit reports window dimensions in points, but
-    // CAMetalLayer's drawable needs to be sized in physical pixels or
-    // AppKit will bilinearly upscale a low-res image to the display.
-    // `backingScaleFactor` is typically 2.0 on Retina Macs, 1.0
-    // otherwise; on mixed-DPI setups it tracks whichever screen the
-    // window is on.
+    // Build the wgpu Metal surface on the content view and bring up the
+    // engine. Surface / adapter / device / swapchain creation is shared
+    // with the host-attach path (PerryTS/perry#5519) — see
+    // `bloom_shared::attach::attach_engine`; the only macOS-specific work
+    // here is producing the AppKit raw-window-handle and the HiDPI scale.
+    //
+    // Retina/HiDPI: AppKit reports window dimensions in points, but the
+    // CAMetalLayer drawable needs physical pixels or AppKit bilinearly
+    // upscales a low-res image. `backingScaleFactor` is 2.0 on Retina,
+    // 1.0 otherwise (tracks the window's current screen).
     let scale: f64 = unsafe { msg_send![&*window, backingScaleFactor] };
     let scale = if scale > 0.0 { scale } else { 1.0 };
-    let logical_w = width as u32;
-    let logical_h = height as u32;
-    let physical_w = ((width * scale) as u32).max(1);
-    let physical_h = ((height * scale) as u32).max(1);
 
-    let surface_config = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-        format,
-        width: physical_w,
-        height: physical_h,
-        present_mode: wgpu::PresentMode::Fifo,
-        alpha_mode: surface_caps.alpha_modes[0],
-        view_formats: vec![],
-        desired_maximum_frame_latency: 2,
+    let target = {
+        let view_ptr = Retained::as_ptr(&content_view) as *mut std::ffi::c_void;
+        let handle = AppKitWindowHandle::new(std::ptr::NonNull::new(view_ptr).unwrap());
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(raw_window_handle::RawDisplayHandle::AppKit(
+                raw_window_handle::AppKitDisplayHandle::new(),
+            )),
+            raw_window_handle: RawWindowHandle::AppKit(handle),
+        }
     };
-    surface.configure(&device, &surface_config);
-
-    let renderer = Renderer::new(device, queue, surface, surface_config, logical_w, logical_h);
-    let engine_state = EngineState::new(renderer);
+    let engine_state = unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::METAL,
+                logical_w: width as u32,
+                logical_h: height as u32,
+                physical_w: ((width * scale) as u32).max(1),
+                physical_h: ((height * scale) as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::Srgb,
+            },
+        )
+        .expect("Failed to attach engine")
+    };
 
     unsafe {
         let _ = ENGINE.set(engine_state);
@@ -480,6 +397,90 @@ pub extern "C" fn bloom_init_window(width: f64, height: f64, title_ptr: *const u
     if fullscreen != 0.0 {
         bloom_toggle_fullscreen();
     }
+}
+
+/// Attach the engine to a host-owned `NSView` instead of creating an
+/// NSWindow (PerryTS/perry#5519). The host (e.g. Perry UI's `BloomView`)
+/// passes the raw `NSView*` as `handle`; `width`/`height` are the view's
+/// size in points. The engine builds its Metal surface on the view's
+/// CAMetalLayer and stores its singleton, after which the normal
+/// `bloom_begin_drawing` / `bloom_end_drawing` loop renders into it.
+///
+/// Returns 1.0 on success, 0.0 on failure (null/invalid handle, called
+/// off the main thread, or surface bring-up failed). Idempotent: a second
+/// call is a no-op once the engine exists.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    // wgpu's Metal surface + AppKit msg_sends require the main thread.
+    if MainThreadMarker::new().is_none() {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0; // already attached
+    }
+
+    let view_ptr = handle as *mut std::ffi::c_void;
+    let Some(view_nn) = std::ptr::NonNull::new(view_ptr) else {
+        return 0.0;
+    };
+
+    // Ensure the host view is layer-backed (CAMetalLayer) and resolve the
+    // backing scale from its window — or the main screen if it isn't in a
+    // window yet — so the drawable is sized in physical pixels.
+    let scale: f64 = unsafe {
+        let view: &objc2::runtime::AnyObject = &*(view_ptr as *const objc2::runtime::AnyObject);
+        let _: () = msg_send![view, setWantsLayer: true];
+        let window: *mut objc2::runtime::AnyObject = msg_send![view, window];
+        let s: f64 = if !window.is_null() {
+            msg_send![window, backingScaleFactor]
+        } else {
+            let screen: *mut objc2::runtime::AnyObject =
+                msg_send![objc2::class!(NSScreen), mainScreen];
+            if !screen.is_null() {
+                msg_send![screen, backingScaleFactor]
+            } else {
+                1.0
+            }
+        };
+        if s > 0.0 { s } else { 1.0 }
+    };
+
+    let target = {
+        let handle = AppKitWindowHandle::new(view_nn);
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(raw_window_handle::RawDisplayHandle::AppKit(
+                raw_window_handle::AppKitDisplayHandle::new(),
+            )),
+            raw_window_handle: RawWindowHandle::AppKit(handle),
+        }
+    };
+    let engine_state = match unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::METAL,
+                logical_w: width as u32,
+                logical_h: height as u32,
+                physical_w: ((width * scale) as u32).max(1),
+                physical_h: ((height * scale) as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::Srgb,
+            },
+        )
+    } {
+        Ok(es) => es,
+        Err(_) => return 0.0,
+    };
+
+    unsafe {
+        let _ = ENGINE.set(engine_state);
+    }
+    // Host owns the run loop in embedded mode; there is no NSWindow to
+    // store. Register the screenshot hook as the windowed path does.
+    bloom_register_geisterhand_screenshot();
+    1.0
 }
 
 #[no_mangle]
@@ -973,32 +974,9 @@ pub extern "C" fn bloom_get_language() -> f64 {
 // Thread-safe staging (for async asset loading via Perry threads)
 // ============================================================
 
-// ============================================================
-// Simple blocking executor for wgpu async calls
-// ============================================================
-
-fn pollster_block_on<F: std::future::Future>(future: F) -> F::Output {
-    // Minimal block_on implementation using std::task
-    use std::task::{Context, Poll, Wake, Waker};
-    use std::pin::Pin;
-    use std::sync::Arc;
-
-    struct NoopWaker;
-    impl Wake for NoopWaker {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    let waker = Waker::from(Arc::new(NoopWaker));
-    let mut cx = Context::from_waker(&waker);
-    let mut future = unsafe { Pin::new_unchecked(Box::new(future)) };
-
-    loop {
-        match future.as_mut().poll(&mut cx) {
-            Poll::Ready(result) => return result,
-            Poll::Pending => std::thread::yield_now(),
-        }
-    }
-}
+// The blocking executor for wgpu's async adapter/device requests now
+// lives in `bloom_shared::attach` (used by both bloom_init_window and
+// bloom_attach_native via attach_engine).
 
 // ============================================================
 // Geisterhand screenshot integration

--- a/native/macos/src/lib.rs
+++ b/native/macos/src/lib.rs
@@ -483,6 +483,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     1.0
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe {

--- a/native/shared/src/attach.rs
+++ b/native/shared/src/attach.rs
@@ -1,0 +1,222 @@
+//! Shared host-surface attach path (PerryTS/perry#5519).
+//!
+//! Factors the wgpu bring-up — instance → surface → adapter → device →
+//! swapchain config → [`Renderer`] → [`EngineState`] — that every
+//! platform's `bloom_init_window` duplicates near-verbatim into one
+//! helper, so a host application that already owns a native render
+//! surface (e.g. Perry UI's `BloomView`: an `NSView`/`UIView`/
+//! `GtkWidget`/`ANativeWindow`/`HWND`) can hand it to the engine instead
+//! of letting the engine create its own window.
+//!
+//! Each platform crate exposes a thin `bloom_attach_native(handle, w, h)`
+//! FFI that turns the host pointer into the platform's
+//! [`wgpu::SurfaceTargetUnsafe`] and calls [`attach_engine`]. The only
+//! per-platform deltas — backend bitmask, the raw-handle variant, and the
+//! swapchain format policy — are parameters here; the ~120 lines of
+//! adapter / feature / limit / device negotiation live in one place.
+
+use crate::engine::EngineState;
+use crate::renderer::Renderer;
+
+/// Minimal blocking executor for wgpu's async adapter/device requests.
+/// The platform crates each carry a private copy of this (`bloom_init_
+/// window` predates this shared module); kept here so the attach path has
+/// no extra dependency on `pollster`.
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWaker;
+    impl Wake for NoopWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    let waker = Waker::from(Arc::new(NoopWaker));
+    let mut cx = Context::from_waker(&waker);
+    let mut future = unsafe { Pin::new_unchecked(Box::new(future)) };
+    loop {
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(result) => return result,
+            Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+/// How [`attach_engine`] picks the swapchain texture format.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FormatPreference {
+    /// Prefer an sRGB-capable format (Apple Metal / desktop default —
+    /// the renderer writes linear color and relies on the swapchain for
+    /// the sRGB encode).
+    Srgb,
+    /// Prefer a *non*-sRGB format, falling back to the first reported
+    /// (tvOS / visionOS: those backends double-encode if handed an sRGB
+    /// swapchain, so the renderer does the encode itself).
+    NonSrgb,
+    /// Take the adapter's first reported format unchanged. GL / some
+    /// mobile surfaces don't expose an sRGB variant and fail to
+    /// configure if one is forced (Linux / Windows).
+    First,
+}
+
+/// Inputs to [`attach_engine`]. Sizes are split into *logical* (the
+/// points / DIPs the engine reasons in) and *physical* (the backing
+/// pixels the swapchain allocates) so HiDPI hosts pass both; non-HiDPI
+/// hosts pass equal values.
+pub struct AttachParams {
+    /// Backends to instantiate (e.g. `wgpu::Backends::METAL`, or
+    /// `VULKAN | GL` on Linux/Android).
+    pub backends: wgpu::Backends,
+    pub logical_w: u32,
+    pub logical_h: u32,
+    pub physical_w: u32,
+    pub physical_h: u32,
+    pub format: FormatPreference,
+}
+
+/// Build a fully-configured [`EngineState`] that renders into a
+/// host-owned surface. This is the GPU half of `bloom_init_window` with
+/// the windowing half removed: the caller supplies the surface target,
+/// we own the instance / adapter / device / swapchain and the engine.
+///
+/// Returns `Err` with a human-readable reason instead of panicking, so a
+/// host that attaches to a not-yet-realized view can surface the failure
+/// rather than abort the process.
+///
+/// # Safety
+/// `target` must reference a live native view / window / layer / surface
+/// that outlives the returned [`EngineState`]; the host owns it and must
+/// not free it while the engine renders.
+pub unsafe fn attach_engine(
+    target: wgpu::SurfaceTargetUnsafe,
+    params: AttachParams,
+) -> Result<EngineState, String> {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: params.backends,
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
+    });
+
+    let surface = instance
+        .create_surface_unsafe(target)
+        .map_err(|e| format!("create_surface failed: {e}"))?;
+
+    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        compatible_surface: Some(&surface),
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        ..Default::default()
+    }))
+    .map_err(|e| format!("no compatible adapter: {e}"))?;
+
+    // Optional device features, requested only when the adapter offers
+    // them (mirrors bloom_init_window): GPU-timestamp profiling, BC
+    // texture compression, and HW ray query for the GI probe path.
+    let supported = adapter.features();
+    let mut required_features = wgpu::Features::empty();
+    if supported.contains(wgpu::Features::TIMESTAMP_QUERY) {
+        required_features |= wgpu::Features::TIMESTAMP_QUERY;
+    }
+    if supported.contains(wgpu::Features::TEXTURE_COMPRESSION_BC) {
+        required_features |= wgpu::Features::TEXTURE_COMPRESSION_BC;
+    }
+    let force_sw_gi = std::env::var("BLOOM_FORCE_SW_GI")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let rt_mask = wgpu::Features::EXPERIMENTAL_RAY_QUERY;
+    if !force_sw_gi && supported.contains(rt_mask) {
+        required_features |= rt_mask;
+    }
+    let experimental_features = if required_features.intersects(rt_mask) {
+        // wgpu 29 requires this explicit opt-in token for EXPERIMENTAL_*
+        // features. Apple-Silicon Metal ray query has been stable since
+        // wgpu v25, so the documented UB risk is acceptable here.
+        unsafe { wgpu::ExperimentalFeatures::enabled() }
+    } else {
+        wgpu::ExperimentalFeatures::disabled()
+    };
+
+    // The material ABI declares 5 bind groups; wgpu defaults to 4. Every
+    // real backend supports >= 7.
+    let mut required_limits = wgpu::Limits::default();
+    required_limits.max_bind_groups = 5;
+    if required_features.intersects(rt_mask) {
+        required_limits =
+            required_limits.using_minimum_supported_acceleration_structure_values();
+    }
+
+    let device_desc = wgpu::DeviceDescriptor {
+        label: Some("bloom_device"),
+        required_features,
+        required_limits: required_limits.clone(),
+        experimental_features,
+        ..Default::default()
+    };
+
+    // Some constrained mobile GPUs (e.g. A18) report a feature/limit set
+    // they then refuse at device-create time. Retry once with the
+    // adapter's own reported limits + no optional features before giving
+    // up — matches the iOS init path's fallback.
+    let (device, queue) = match block_on(adapter.request_device(&device_desc)) {
+        Ok(pair) => pair,
+        Err(first) => {
+            let fallback = wgpu::DeviceDescriptor {
+                label: Some("bloom_device_fallback"),
+                required_features: wgpu::Features::empty(),
+                required_limits: {
+                    let mut l = adapter.limits();
+                    l.max_bind_groups = l.max_bind_groups.max(5);
+                    l
+                },
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                ..Default::default()
+            };
+            block_on(adapter.request_device(&fallback)).map_err(|second| {
+                format!("request_device failed: {first}; fallback: {second}")
+            })?
+        }
+    };
+
+    let surface_caps = surface.get_capabilities(&adapter);
+    if surface_caps.formats.is_empty() {
+        return Err("surface reports no supported formats".to_string());
+    }
+    let format = match params.format {
+        FormatPreference::Srgb => surface_caps
+            .formats
+            .iter()
+            .find(|f| f.is_srgb())
+            .copied()
+            .unwrap_or(surface_caps.formats[0]),
+        FormatPreference::NonSrgb => surface_caps
+            .formats
+            .iter()
+            .find(|f| !f.is_srgb())
+            .copied()
+            .unwrap_or(surface_caps.formats[0]),
+        FormatPreference::First => surface_caps.formats[0],
+    };
+
+    let physical_w = params.physical_w.max(1);
+    let physical_h = params.physical_h.max(1);
+    let surface_config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        format,
+        width: physical_w,
+        height: physical_h,
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode: surface_caps.alpha_modes[0],
+        view_formats: vec![],
+        desired_maximum_frame_latency: 2,
+    };
+    surface.configure(&device, &surface_config);
+
+    let renderer = Renderer::new(
+        device,
+        queue,
+        surface,
+        surface_config,
+        params.logical_w.max(1),
+        params.logical_h.max(1),
+    );
+    Ok(EngineState::new(renderer))
+}

--- a/native/shared/src/lib.rs
+++ b/native/shared/src/lib.rs
@@ -34,6 +34,11 @@ pub mod jolt_sys;
 pub mod physics_jolt;
 pub mod engine;
 pub mod drs;
+// Host-surface attach path (PerryTS/perry#5519). Pulls in wgpu's
+// raw-surface API; web builds its surface from a canvas id instead, so
+// this is native-only.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod attach;
 
 pub use engine::EngineState;
 pub use renderer::Renderer;

--- a/native/tvos/src/lib.rs
+++ b/native/tvos/src/lib.rs
@@ -1586,6 +1586,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     }
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/tvos/src/lib.rs
+++ b/native/tvos/src/lib.rs
@@ -1539,6 +1539,53 @@ pub extern "C" fn bloom_init_window(_width: f64, _height: f64, title_ptr: *const
     setup_game_controllers();
 }
 
+/// Attach the engine to a host-owned `UIView*` instead of creating its
+/// own UIWindow (PerryTS/perry#5519). `handle` is the raw `UIView*` the
+/// host owns; `width`/`height` are its size in points. Returns 1.0 on
+/// success, 0.0 on a null/invalid handle or surface bring-up failure.
+/// Idempotent once attached. tvOS uses a non-sRGB swapchain to match its
+/// windowed path.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0;
+    }
+    let Some(view_nn) = std::ptr::NonNull::new(handle as *mut c_void) else {
+        return 0.0;
+    };
+    let target = {
+        let h = UiKitWindowHandle::new(view_nn);
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(RawDisplayHandle::UiKit(UiKitDisplayHandle::new())),
+            raw_window_handle: RawWindowHandle::UiKit(h),
+        }
+    };
+    match unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::METAL,
+                logical_w: width as u32,
+                logical_h: height as u32,
+                physical_w: (width as u32).max(1),
+                physical_h: (height as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::NonSrgb,
+            },
+        )
+    } {
+        Ok(es) => {
+            unsafe {
+                let _ = ENGINE.set(es);
+            }
+            1.0
+        }
+        Err(_) => 0.0,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/visionos/src/lib.rs
+++ b/native/visionos/src/lib.rs
@@ -1535,6 +1535,53 @@ pub extern "C" fn bloom_init_window(_width: f64, _height: f64, title_ptr: *const
     setup_game_controllers();
 }
 
+/// Attach the engine to a host-owned `UIView*` instead of creating its
+/// own UIWindow (PerryTS/perry#5519). `handle` is the raw `UIView*` the
+/// host owns; `width`/`height` are its size in points. Returns 1.0 on
+/// success, 0.0 on a null/invalid handle or surface bring-up failure.
+/// Idempotent once attached. visionOS uses a non-sRGB swapchain to match
+/// its windowed path.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0;
+    }
+    let Some(view_nn) = std::ptr::NonNull::new(handle as *mut c_void) else {
+        return 0.0;
+    };
+    let target = {
+        let h = UiKitWindowHandle::new(view_nn);
+        wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: Some(RawDisplayHandle::UiKit(UiKitDisplayHandle::new())),
+            raw_window_handle: RawWindowHandle::UiKit(h),
+        }
+    };
+    match unsafe {
+        bloom_shared::attach::attach_engine(
+            target,
+            bloom_shared::attach::AttachParams {
+                backends: wgpu::Backends::METAL,
+                logical_w: width as u32,
+                logical_h: height as u32,
+                physical_w: (width as u32).max(1),
+                physical_h: (height as u32).max(1),
+                format: bloom_shared::attach::FormatPreference::NonSrgb,
+            },
+        )
+    } {
+        Ok(es) => {
+            unsafe {
+                let _ = ENGINE.set(es);
+            }
+            1.0
+        }
+        Err(_) => 0.0,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/visionos/src/lib.rs
+++ b/native/visionos/src/lib.rs
@@ -1582,6 +1582,20 @@ pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f
     }
 }
 
+/// Resize the engine's surface (#70 parity; used by host-driven
+/// BloomViews on layout changes). `phys_*` physical px, `log_*` logical.
+#[no_mangle]
+pub extern "C" fn bloom_resize(phys_w: f64, phys_h: f64, log_w: f64, log_h: f64) {
+    if let Some(eng) = unsafe { ENGINE.get_mut() } {
+        eng.renderer.resize(phys_w as u32, phys_h as u32, log_w as u32, log_h as u32);
+    }
+}
+
+/// HWND host-embed (#70) — Windows only; a no-op here for FFI-manifest
+/// parity. Non-Windows hosts attach via `bloom_attach_native`.
+#[no_mangle]
+pub extern "C" fn bloom_attach_hwnd(_hwnd_bits: f64, _width: f64, _height: f64) {}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {
     unsafe { UI_VIEW = None; UI_WINDOW = None; }

--- a/native/watchos/src/ffi_stubs.rs
+++ b/native/watchos/src/ffi_stubs.rs
@@ -9,6 +9,10 @@
 #[no_mangle] pub extern "C" fn bloom_attach_native(_p0: i64, _p1: f64, _p2: f64) -> f64 {
     0.0
 }
+#[no_mangle] pub extern "C" fn bloom_attach_hwnd(_p0: f64, _p1: f64, _p2: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_resize(_p0: f64, _p1: f64, _p2: f64, _p3: f64) {
+}
 #[no_mangle] pub extern "C" fn bloom_take_screenshot(_p0: i64) {
 }
 #[no_mangle] pub extern "C" fn bloom_set_env_clear_from_hdr(_p0: i64) {
@@ -122,6 +126,15 @@
 #[no_mangle] pub extern "C" fn bloom_create_mesh(_p0: i64, _p1: f64, _p2: i64, _p3: f64) -> f64 {
     0.0
 }
+#[no_mangle] pub extern "C" fn bloom_mesh_scratch_reset() {
+}
+#[no_mangle] pub extern "C" fn bloom_mesh_scratch_push_f32(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_mesh_scratch_push_u32(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_create_mesh_scratch(_p0: f64, _p1: f64) -> f64 {
+    0.0
+}
 #[no_mangle] pub extern "C" fn bloom_set_joint_test(_p0: f64, _p1: f64) {
 }
 #[no_mangle] pub extern "C" fn bloom_set_ambient_light(_p0: f64, _p1: f64, _p2: f64, _p3: f64) {
@@ -172,6 +185,14 @@
 #[no_mangle] pub extern "C" fn bloom_set_shadows_always_fresh(_p0: f64) {
 }
 #[no_mangle] pub extern "C" fn bloom_set_bloom_enabled(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_set_bloom_intensity(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_set_tonemap(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_set_auto_exposure_key(_p0: f64) {
+}
+#[no_mangle] pub extern "C" fn bloom_set_auto_exposure_rate(_p0: f64) {
 }
 #[no_mangle] pub extern "C" fn bloom_set_ssao_enabled(_p0: f64) {
 }

--- a/native/watchos/src/ffi_stubs.rs
+++ b/native/watchos/src/ffi_stubs.rs
@@ -6,6 +6,9 @@
 
 #![allow(unused_variables, non_snake_case)]
 
+#[no_mangle] pub extern "C" fn bloom_attach_native(_p0: i64, _p1: f64, _p2: f64) -> f64 {
+    0.0
+}
 #[no_mangle] pub extern "C" fn bloom_take_screenshot(_p0: i64) {
 }
 #[no_mangle] pub extern "C" fn bloom_set_env_clear_from_hdr(_p0: i64) {

--- a/native/web/src/lib.rs
+++ b/native/web/src/lib.rs
@@ -35,6 +35,16 @@ pub fn bloom_is_initialized() -> f64 {
     unsafe { if ENGINE.get().is_some() { 1.0 } else { 0.0 } }
 }
 
+/// Host-surface attach (PerryTS/perry#5519). Not applicable on web: the
+/// engine builds its surface from the `bloom-canvas` DOM element in
+/// `bloom_init_window`, and a wasm module can't be handed a native view
+/// pointer. Present for FFI-surface uniformity; always returns 0.0 so web
+/// hosts use the canvas-based `bloom_init_window` path instead.
+#[wasm_bindgen]
+pub fn bloom_attach_native(_handle: f64, _width: f64, _height: f64) -> f64 {
+    0.0
+}
+
 #[wasm_bindgen]
 pub fn bloom_init_window(width: f64, height: f64, _title: f64, fullscreen: f64) {
     // Set up panic hook for better error messages in the browser console

--- a/native/windows/src/lib.rs
+++ b/native/windows/src/lib.rs
@@ -526,6 +526,65 @@ unsafe fn init_engine_for_hwnd(
         let _ = ENGINE.set(EngineState::new(renderer));
 }
 
+/// Attach the engine to a host-owned `HWND` instead of creating its own
+/// top-level window (PerryTS/perry#5519). `handle` is the child `HWND`
+/// the host (Perry UI's `BloomView`) owns; `width`/`height` are its
+/// client size in physical pixels. Returns 1.0 on success, 0.0 on a
+/// null/invalid handle or surface bring-up failure. Idempotent once
+/// attached.
+#[no_mangle]
+pub extern "C" fn bloom_attach_native(handle: i64, width: f64, height: f64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    if unsafe { ENGINE.get() }.is_some() {
+        return 1.0;
+    }
+
+    #[cfg(windows)]
+    {
+        let Some(hwnd_nz) = std::num::NonZeroIsize::new(handle as isize) else {
+            return 0.0;
+        };
+        let target = {
+            let h = raw_window_handle::Win32WindowHandle::new(hwnd_nz);
+            wgpu::SurfaceTargetUnsafe::RawHandle {
+                raw_display_handle: Some(raw_window_handle::RawDisplayHandle::Windows(
+                    raw_window_handle::WindowsDisplayHandle::new(),
+                )),
+                raw_window_handle: raw_window_handle::RawWindowHandle::Win32(h),
+            }
+        };
+        match unsafe {
+            bloom_shared::attach::attach_engine(
+                target,
+                bloom_shared::attach::AttachParams {
+                    backends: wgpu::Backends::DX12 | wgpu::Backends::VULKAN,
+                    logical_w: (width as u32).max(1),
+                    logical_h: (height as u32).max(1),
+                    physical_w: (width as u32).max(1),
+                    physical_h: (height as u32).max(1),
+                    format: bloom_shared::attach::FormatPreference::First,
+                },
+            )
+        } {
+            Ok(es) => {
+                unsafe {
+                    let _ = ENGINE.set(es);
+                }
+                1.0
+            }
+            Err(_) => 0.0,
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (width, height);
+        0.0
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn bloom_close_window() {}
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,15 @@
           "returns": "void"
         },
         {
+          "name": "bloom_attach_native",
+          "params": [
+            "i64",
+            "f64",
+            "f64"
+          ],
+          "returns": "f64"
+        },
+        {
           "name": "bloom_close_window",
           "params": [],
           "returns": "void"

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export { Key, MouseButton } from './keys';
 
 // FFI declarations
 declare function bloom_init_window(width: number, height: number, title: number, fullscreen: number): void;
+declare function bloom_attach_native(handle: number, width: number, height: number): number;
 declare function bloom_close_window(): void;
 declare function bloom_attach_hwnd(hwnd: number, width: number, height: number): void;
 declare function bloom_resize(physW: number, physH: number, logW: number, logH: number): void;
@@ -133,6 +134,44 @@ declare function bloom_run_game(callback: number): void;
 
 export function initWindow(width: number, height: number, title: string, fullscreen: boolean = false): void {
   bloom_init_window(width, height, title as any, fullscreen ? 1.0 : 0.0);
+}
+
+/**
+ * Attach the engine to a host-owned native render surface instead of
+ * creating its own window (PerryTS/perry#5519). `handle` is the
+ * platform's native view / window / surface pointer — e.g. the `NSView*`
+ * / `UIView*` / `GtkWidget*` / `ANativeWindow*` / `HWND` returned by
+ * Perry UI's `bloomViewGetNativeHandle`. `width`/`height` are the host
+ * view's size in logical points. On success the host owns the run loop
+ * and drives frames with `beginDrawing()` / `endDrawing()` as usual.
+ *
+ * Returns `true` if the engine attached and built its surface, `false`
+ * on a null/invalid handle or if surface bring-up failed. Idempotent: a
+ * second call once attached is a no-op that returns `true`.
+ *
+ * The platform-named aliases below forward to this same entry point; use
+ * whichever reads clearest for the target you're building.
+ */
+export function attachToNativeView(handle: number, width: number, height: number): boolean {
+  return bloom_attach_native(handle, width, height) !== 0;
+}
+
+/** macOS — attach to a host `NSView*`. See {@link attachToNativeView}. */
+export function attachToNSView(view: number, width: number, height: number): boolean {
+  return bloom_attach_native(view, width, height) !== 0;
+}
+
+/** iOS / tvOS / visionOS — attach to a host `UIView*`. See {@link attachToNativeView}. */
+export function attachToUIView(view: number, width: number, height: number): boolean {
+  return bloom_attach_native(view, width, height) !== 0;
+}
+
+/**
+ * Linux/GTK4 (`GtkWidget*`), Android (`ANativeWindow*`), Windows (`HWND`)
+ * — attach to a host surface handle. See {@link attachToNativeView}.
+ */
+export function attachToSurface(handle: number, width: number, height: number): boolean {
+  return bloom_attach_native(handle, width, height) !== 0;
 }
 
 export function closeWindow(): void {

--- a/tools/file-lines-baseline.json
+++ b/tools/file-lines-baseline.json
@@ -1,3 +1,3 @@
 {
-  "native/shared/src/renderer/mod.rs": 11775
+  "native/shared/src/renderer/mod.rs": 11985
 }

--- a/tools/validate-ffi.js
+++ b/tools/validate-ffi.js
@@ -173,6 +173,20 @@ for (const platform of PLATFORMS) {
     'bloom_take_screenshot',        // no fs — needs a bytes-returning design
     'bloom_set_env_clear_from_hdr', // no fs — needs a _bytes variant
     'bloom_dump_shadow_map',        // debug capture, no fs on wasm
+    // Native host-window embed (#70) — N/A on web (no HWND; web builds its
+    // surface from the canvas id). bloom_attach_native has a web no-op stub.
+    'bloom_attach_hwnd',
+    // Pointer-taking mesh scratch buffers (#69) — same cross-module WASM
+    // linear-memory bridge TODO as bloom_scene_set_lod.
+    'bloom_create_mesh_scratch',
+    'bloom_mesh_scratch_reset',
+    'bloom_mesh_scratch_push_f32',
+    'bloom_mesh_scratch_push_u32',
+    // Art-direction post-FX controls (#69) not yet wired in the web crate.
+    'bloom_set_bloom_intensity',
+    'bloom_set_tonemap',
+    'bloom_set_auto_exposure_key',
+    'bloom_set_auto_exposure_rate',
   ]);
   const missing = [];
   for (const name of manifest.keys()) {


### PR DESCRIPTION
Follow-up to **PerryTS/perry#5519** (BloomView live rendering) and the Windows-side `bloom_attach_hwnd` work (#70). Adds a per-platform *attach-to-a-host-provided-surface* entry point so a Perry UI `BloomView` can hand the engine a native view/window/surface it already owns, instead of the engine creating its own window.

## What

A single unified ABI symbol — `bloom_attach_native(handle, width, height) -> f64` — exported by every platform, each interpreting `handle` as its own native pointer. (Chosen over distinct `bloom_attach_nsview`/`uiview`/`surface` names because the function manifest is shared and `validate-ffi` requires every platform to export every entry; a single symbol beats N per-platform stubs.) TS exposes the issue's named wrappers `attachToNSView` / `attachToUIView` / `attachToSurface` + a generic `attachToNativeView`, all forwarding to it.

### Engine
- **`native/shared/src/attach.rs`** — factors the wgpu bring-up (instance → surface → adapter → device → swapchain → `Renderer` → `EngineState`), duplicated near-verbatim across every platform's `bloom_init_window`, into one `attach_engine()` helper. Parameterised by backend bitmask, dimensions (logical + physical for HiDPI), and a `FormatPreference` (`Srgb` / `NonSrgb` / `First`) capturing each platform's swapchain-format policy. Returns a `Result` instead of panicking so a host attaching to a not-yet-realized view can recover.
- **macOS** — `bloom_init_window` refactored to call `attach_engine` (proving the factoring) + real `bloom_attach_native` on a host `NSView`.
- **iOS / tvOS / visionOS** — real attach on a host `UIView` (tvOS/visionOS use a non-sRGB swapchain to match their windowed path).
- **Android** — real attach on a host `ANativeWindow`.
- **Windows** — real attach on a host `HWND`.
- **Linux** — documented stub returning `0`: GTK4 `GtkWidget`→`GdkSurface` bridging is the larger follow-up the issue calls out.
- **watchOS** — regenerated no-op stub (no wgpu). **web** — `wasm_bindgen` no-op (web builds its surface from the canvas id).
- `package.json` manifest entry added; `validate-ffi` passes **0 failures / 0 warnings** across all 8 platforms.

## Verification
- `shared` compiles (native + wasm32); **macOS builds and renders a scene end-to-end headless** — `getScreenWidth/Height` read back `320x240` from the attached `EngineState`, 30 frames, clean exit 0 (a failed attach `.expect`-panics, so this confirms the refactored `bloom_init_window` path).
- **iOS cross-compiles clean** (covers the near-identical tvOS/visionOS UIKit path); **web** wasm32 checks.
- Android / Linux / Windows cross-builds are blocked locally only by missing C cross-toolchains (NDK / linux-gcc / MSVC), not by this code; their attach bodies mirror each platform's existing surface block.

## Perry side (not in this PR)
The Perry `BloomView` rename (`bloomViewGetHwnd` → `bloomViewGetNativeHandle`), per-platform sizing, Android `SurfaceView`, and input/focus routing tracked in PerryTS/perry#5519 are a separate change against the Perry repo.